### PR TITLE
Fix build error with JDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,8 @@ project(':clickhouse-core') {
             exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
         }
 
+        compileOnly "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_api_version"
+
         testFixturesApi "org.slf4j:slf4j-api:$slf4j_version"
         testFixturesApi "org.scalatest:scalatest_$scala_binary_version:$scalatest_version"
         testFixturesRuntimeOnly "com.vladsch.flexmark:flexmark-all:$flexmark_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,10 @@ grpc_version=1.43.2
 guava_version=30.1.1-jre
 protobuf_version=3.19.2
 
+# javax annotations removed in jdk 11
+# fix build error with jakarta annotations
+jakarta_annotation_api_version=1.3.5
+
 # Test only
 clickhouse_jdbc_version=0.3.2-patch5
 testcontainers_scala_version=0.40.2


### PR DESCRIPTION
JDK 11 removes `javax.annotation`

Close #64