### PR TITLE
Fix: Fallback to UnknownTableEngineSpec when parseEngineClause failed

### DIFF
--- a/clickhouse-core/src/main/scala/xenon/clickhouse/spec/TableEngineUtils.scala
+++ b/clickhouse-core/src/main/scala/xenon/clickhouse/spec/TableEngineUtils.scala
@@ -24,7 +24,7 @@ object TableEngineUtils extends Logging {
     try ParseUtils.parser.parseEngineClause(tableSpec.engine_full)
     catch {
       case cause: ParseException =>
-        log.warn(s"Unknown table engine for table ${tableSpec.database}.${tableSpec.name}: ${cause.message}")
+        log.warn(s"Unknown table engine for table ${tableSpec.database}.${tableSpec.name}: ${tableSpec.engine_full}")
         UnknownTableEngineSpec(tableSpec.engine_full)
     }
   }

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/ClickHouseSingleSuite.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/ClickHouseSingleSuite.scala
@@ -57,6 +57,13 @@ class ClickHouseSingleSuite extends BaseSparkSuite
     }
   }
 
+  test("clickhouse system table") {
+    checkAnswer(
+      spark.sql("SELECT time_zone FROM `system`.`time_zones` WHERE time_zone = 'Asia/Shanghai'"),
+      Row("Asia/Shanghai") :: Nil
+    )
+  }
+
   test("clickhouse partition") {
     val db = "db_part"
     val tbl = "tbl_part"


### PR DESCRIPTION
For system tables, `engine_full` is empty string, we should support this case otherwise can not read the system table.