### PR TITLE
Support partitioned by Date Type

### DIFF
--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
@@ -15,7 +15,7 @@
 package xenon.clickhouse
 
 import java.lang.{Integer => JInt, Long => JLong}
-import java.time.ZoneId
+import java.time.{LocalDate, ZoneId}
 import java.util
 
 import scala.collection.JavaConverters._
@@ -223,6 +223,7 @@ case class ClickHouseTable(
       case StringType => UTF8String.fromString(str.stripPrefix("'").stripSuffix("'"))
       case IntegerType => JInt.parseInt(str)
       case LongType => JLong.parseLong(str)
+      case DateType => LocalDate.parse(str.stripPrefix("'").stripSuffix("'"), dateFmt).toEpochDay.toInt
       case unsupported => throw new UnsupportedOperationException(s"$unsupported")
     }
 

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/read/InputPartitions.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/read/InputPartitions.scala
@@ -40,6 +40,11 @@ case class ClickHouseInputPartition(
 
   def partFilterExpr: String = partition match {
     case NoPartitionSpec => "1=1"
-    case PartitionSpec(part, _, _) => s"${table.partition_key} = $part"
+    case PartitionSpec(part, _, _) => (part.contains("-"), part.contains("(")) match {
+      // quote when partition by a single Date Type column to avoid illegal types of arguments (Date, Int64)
+      case (true, false) => s"${table.partition_key} = '$part'"
+      // Date type column is quoted if there are multi partition columns
+      case _ => s"${table.partition_key} = $part"
+    }
   }
 }


### PR DESCRIPTION
unquoted partition condition may cause error like below when partition column type is Date
`xenon.clickhouse.exception.ClickHouseServerException: [43] DB::Exception: Illegal types of arguments (Date, Int64) of function equals: While processing load_date = ((2022 - 4) - 12)`