### PR TITLE
Use Arm64 base image when building on Linux ARM64

### DIFF
--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -36,11 +36,26 @@ SCALA_BINARY_VERSION=2.12
 SPARK_VERSION=3.2.1
 SPARK_BINARY_VERSION=3.2
 
+ARCH=$(uname -m)
+if test $ARCH = "x86_64"; then
+  BASE_IMAGE="ubuntu"
+  JDK_ARCH="amd64"
+elif test $ARCH = "aarch64"; then
+  BASE_IMAGE="arm64v8/ubuntu"
+  JDK_ARCH="arm64"
+else 
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
+
+
 docker build \
   --build-arg UBUNTU_MIRROR=${UBUNTU_MIRROR} \
   --build-arg APACHE_MIRROR=${APACHE_MIRROR} \
   --build-arg MAVEN_MIRROR=${MAVEN_MIRROR} \
   --build-arg PROJECT_VERSION=${PROJECT_VERSION} \
+  --build-arg BASE_IMAGE=${BASE_IMAGE} \
+  --build-arg JDK_ARCH=${JDK_ARCH} \
   --file "${SELF_DIR}/image/scc-base.Dockerfile" \
   --tag scc-base:${PROJECT_VERSION} \
   "${SELF_DIR}/image" $@

--- a/docker/image/scc-base.Dockerfile
+++ b/docker/image/scc-base.Dockerfile
@@ -10,14 +10,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
-MAINTAINER Cheng Pan<chengpan@apache.com>
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}:20.04
+LABEL org.opencontainers.image.authors="Cheng Pan<chengpan@apache.com>"
 
 ARG UBUNTU_MIRROR
+ARG JDK_ARCH
 
 ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-${JDK_ARCH}
 
 RUN sed -i "s/archive.ubuntu.com/${UBUNTU_MIRROR}/g" /etc/apt/sources.list && \
     sed -i "s/security.ubuntu.com/${UBUNTU_MIRROR}/g" /etc/apt/sources.list && \


### PR DESCRIPTION
Point to AMD64/ARM64 JDK depending on the CPU arch
Replace deprecated MAINTAINER with LABEL (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>