### PR TITLE
Support create Distributed table

### DIFF
--- a/docs/quick_start/02_play_with_spark_sql.md
+++ b/docs/quick_start/02_play_with_spark_sql.md
@@ -68,7 +68,7 @@ spark-sql> CREATE TABLE test_db.tbl_sql (
          > PARTITIONED BY (m)
          > TBLPROPERTIES (
          >   engine = 'MergeTree()',
-         >   order_by = '(id)',
+         >   order_by = 'id',
          >   settings.index_granularity = 8192
          > );
 Time taken: 0.242 seconds

--- a/docs/quick_start/03_play_with_spark_shell.md
+++ b/docs/quick_start/03_play_with_spark_shell.md
@@ -69,7 +69,7 @@ scala> spark.sql("""
      | PARTITIONED BY (m)
      | TBLPROPERTIES (
      |   engine = 'MergeTree()',
-     |   order_by = '(id)',
+     |   order_by = 'id',
      |   settings.index_granularity = 8192
      | )
      | """)

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/BaseSparkSuite.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/BaseSparkSuite.scala
@@ -94,7 +94,7 @@ abstract class BaseSparkSuite extends AnyFunSuite with BeforeAndAfterAll with Ev
          |) USING ClickHouse
          |TBLPROPERTIES (
          |  engine = 'MergeTree()',
-         |  order_by = '(id)',
+         |  order_by = 'id',
          |  settings.index_granularity = 8192
          |)
          |""".stripMargin

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/cluster/ClusterTableManagementSuite.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/cluster/ClusterTableManagementSuite.scala
@@ -32,26 +32,26 @@ class ClusterTableManagementSuite extends BaseSparkSuite
            |TBLPROPERTIES (
            |  cluster = '$cluster',
            |  engine = 'MergeTree()',
-           |  order_by = '(id)',
+           |  order_by = 'id',
            |  settings.index_granularity = 8192
            |)
            |""".stripMargin
       )
 
-      def createOrReplaceTable(): Unit = spark.sql(
-        s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl_dist` (
+      def createOrReplaceLocalTable(): Unit = spark.sql(
+        s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl_local` (
            |  id Long NOT NULL
            |) USING ClickHouse
            |TBLPROPERTIES (
            |  engine = 'MergeTree()',
-           |  order_by = '(id)',
+           |  order_by = 'id',
            |  settings.index_granularity = 8192
            |)
            |""".stripMargin
       )
       createLocalTable()
-      createOrReplaceTable()
-      createOrReplaceTable()
+      createOrReplaceLocalTable()
+      createOrReplaceLocalTable()
     }
   }
 }

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/ClickHouseSingleSuite.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/ClickHouseSingleSuite.scala
@@ -398,7 +398,7 @@ class ClickHouseSingleSuite extends BaseSparkSuite
            |) USING ClickHouse
            |TBLPROPERTIES (
            |  engine = 'MergeTree()',
-           |  order_by = '(id)',
+           |  order_by = 'id',
            |  settings.index_granularity = 8192
            |)
            |""".stripMargin

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/SparkClickHouseSingleTestHelper.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/xenon/clickhouse/single/SparkClickHouseSingleTestHelper.scala
@@ -38,7 +38,7 @@ trait SparkClickHouseSingleTestHelper { self: BaseSparkSuite with SparkClickHous
            |) USING ClickHouse
            |${if (partKeys.isEmpty) "" else partKeys.mkString("PARTITIONED BY(", ", ", ")")}
            |TBLPROPERTIES (
-           |  ${if (sortKeys.isEmpty) "" else sortKeys.mkString("order_by = '(", ", ", ")',")}
+           |  ${if (sortKeys.isEmpty) "" else sortKeys.mkString("order_by = '", ", ", "',")}
            |  engine = '$engine'
            |)
            |""".stripMargin
@@ -69,7 +69,7 @@ trait SparkClickHouseSingleTestHelper { self: BaseSparkSuite with SparkClickHous
            |PARTITIONED BY (m)
            |TBLPROPERTIES (
            |  engine = 'MergeTree()',
-           |  order_by = '(id)'
+           |  order_by = 'id'
            |)
            |""".stripMargin
       )

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseCatalog.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseCatalog.scala
@@ -212,7 +212,7 @@ class ClickHouseCatalog extends TableCatalog
 
     val clusterOpt = props.get("cluster")
 
-    def settingsClause(prefix: String): String = props.filterKeys(_.startsWith(prefix)) match {
+    def tblSettingsClause(prefix: String): String = props.filterKeys(_.startsWith(prefix)) match {
       case settings if settings.nonEmpty =>
         settings.map { case (k, v) =>
           s"${k.substring(prefix.length)}=$v"
@@ -261,15 +261,15 @@ class ClickHouseCatalog extends TableCatalog
     if (isCreatingDistributed) {
       val cluster = clusterOpt.getOrElse("default")
       val shardExpr = props.getOrElse("shard_by", "rand()")
-      val settingsClause = settingsClause("settings.")
+      val settingsClause = tblSettingsClause("settings.")
       val localEngineExpr = props.getOrElse(s"${keyPrefix}engine", s"MergeTree()")
       val localDatabase = props.getOrElse(s"${keyPrefix}database", db)
       val localTable = props.getOrElse(s"${keyPrefix}table", s"${tbl}_local")
-      val localSettingsClause = settingsClause(s"${keyPrefix}settings.")
+      val localSettingsClause = tblSettingsClause(s"${keyPrefix}settings.")
       createTable(Some(cluster), localEngineExpr, localDatabase, localTable, localSettingsClause)
       createDistributedTable(cluster, shardExpr, localDatabase, localTable, db, tbl, settingsClause)
     } else {
-      val settingsClause = settingsClause(s"${keyPrefix}settings.")
+      val settingsClause = tblSettingsClause(s"${keyPrefix}settings.")
       createTable(clusterOpt, engineExpr, db, tbl, settingsClause)
     }
 

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseCatalog.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseCatalog.scala
@@ -14,11 +14,6 @@
 
 package xenon.clickhouse
 
-import java.time.ZoneId
-import java.util
-
-import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.clickhouse.ExprUtils
 import org.apache.spark.sql.connector.catalog._
@@ -27,11 +22,15 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import xenon.clickhouse.Constants._
-import xenon.clickhouse.exception.{ClickHouseClientException, ClickHouseServerException}
 import xenon.clickhouse.exception.ClickHouseErrCode._
+import xenon.clickhouse.exception.{ClickHouseClientException, ClickHouseServerException}
 import xenon.clickhouse.func.{ClickHouseXxHash64, ClickHouseXxHash64Shard}
 import xenon.clickhouse.grpc.GrpcNodeClient
 import xenon.clickhouse.spec._
+
+import java.time.ZoneId
+import java.util
+import scala.collection.JavaConverters._
 
 class ClickHouseCatalog extends TableCatalog
     with SupportsNamespaces
@@ -176,8 +175,6 @@ class ClickHouseCatalog extends TableCatalog
    * }}}
    *
    * `ver` — column with version. Type `UInt*`, `Date` or `DateTime`.
-   *
-   * TODO Support create Distributed tables
    */
   @throws[TableAlreadyExistsException]
   @throws[NoSuchNamespaceException]
@@ -192,42 +189,89 @@ class ClickHouseCatalog extends TableCatalog
       case None => throw ClickHouseClientException(s"Invalid table identifier: $ident")
     }
     val props = properties.asScala
-    val engineClause = props.get("engine").map(e => s"ENGINE = $e")
-      .getOrElse(throw ClickHouseClientException("Missing property 'engine'"))
+
+    val engineExpr = props.getOrElse("engine", "MergeTree()")
+
+    val isCreatingDistributed = engineExpr equalsIgnoreCase "Distributed"
+    val keyPrefix = if (isCreatingDistributed) "local." else ""
+
     val partitionsClause = partitions match {
       case transforms if transforms.nonEmpty =>
         transforms.map(ExprUtils.toClickHouse(_).sql).mkString("PARTITION BY (", ", ", ")")
       case _ => ""
     }
-    // TODO we need consider to support other DML, like alter table, drop table, truncate table ...
-    val clusterClause = props.get("cluster").map(c => s"ON CLUSTER $c").getOrElse("")
-    val orderClause = props.get("order_by").map(o => s"ORDER BY $o").getOrElse("")
-    val primaryKeyClause = props.get("primary_key").map(p => s"PRIMARY KEY $p").getOrElse("")
-    val sampleClause = props.get("sample_by").map(p => s"SAMPLE BY $p").getOrElse("")
 
-    val settingsClause = props.filterKeys(_.startsWith("settings.")) match {
-      case settings if settings.nonEmpty =>
-        settings.map { case (k, v) => s"${k.substring("settings.".length)}=$v" }.mkString("SETTINGS ", ", ", "")
-      case _ => ""
-    }
+    val orderClause = props.get(s"${keyPrefix}order_by").map(o => s"ORDER BY ($o)").getOrElse("")
+    val primaryKeyClause = props.get(s"${keyPrefix}primary_key").map(p => s"PRIMARY KEY ($p)").getOrElse("")
+    val sampleClause = props.get(s"${keyPrefix}sample_by").map(p => s"SAMPLE BY ($p)").getOrElse("")
 
     val fieldsClause = SchemaUtils
       .toClickHouseSchema(schema)
       .map { case (fieldName, ckType) => s"${quoted(fieldName)} $ckType" }
       .mkString(",\n ")
 
-    grpcNodeClient.syncQueryAndCheckOutputJSONEachRow(
-      s"""CREATE TABLE `$db`.`$tbl` $clusterClause (
-         |$fieldsClause
-         |) $engineClause
-         |$partitionsClause
-         |$orderClause
-         |$primaryKeyClause
-         |$sampleClause
+    val clusterOpt = props.get("cluster")
+
+    def settingsClause(prefix: String): String = props.filterKeys(_.startsWith(prefix)) match {
+      case settings if settings.nonEmpty =>
+        settings.map { case (k, v) =>
+          s"${k.substring(prefix.length)}=$v"
+        }.mkString("SETTINGS ", ", ", "")
+      case _ => ""
+    }
+
+    def createTable(
+      clusterOpt: Option[String],
+      engineExpr: String,
+      database: String,
+      table: String,
+      settingsClause: String
+    ): Unit = {
+      val clusterClause = clusterOpt.map(c => s"ON CLUSTER $c").getOrElse("")
+      grpcNodeClient.syncQueryAndCheckOutputJSONEachRow(
+        s"""CREATE TABLE `$database`.`$table` $clusterClause (
+           |$fieldsClause
+           |) ENGINE = $engineExpr
+           |$partitionsClause
+           |$orderClause
+           |$primaryKeyClause
+           |$sampleClause
+           |$settingsClause
+           |""".stripMargin
+          .replaceAll("""\n\s+\n""", "\n") // remove empty lines
+      )
+    }
+
+    def createDistributedTable(
+      cluster: String,
+      shardExpr: String,
+      localDatabase: String,
+      localTable: String,
+      distributedDatabase: String,
+      distributedTable: String,
+      settingsClause: String
+    ): Unit = grpcNodeClient.syncQueryAndCheckOutputJSONEachRow(
+      s"""CREATE TABLE `$distributedDatabase`.`$distributedTable` ON CLUSTER $cluster
+         |AS `$localDatabase`.`$localTable`
+         |ENGINE = Distributed($cluster, '$localDatabase', '$localTable', ($shardExpr))
          |$settingsClause
          |""".stripMargin
-        .replaceAll("""\n\s+\n""", "\n") // remove empty lines
     )
+
+    if (isCreatingDistributed) {
+      val cluster = clusterOpt.getOrElse("default")
+      val shardExpr = props.getOrElse("shard_by", "rand()")
+      val settingsClause = settingsClause("settings.")
+      val localEngineExpr = props.getOrElse(s"${keyPrefix}engine", s"MergeTree()")
+      val localDatabase = props.getOrElse(s"${keyPrefix}database", db)
+      val localTable = props.getOrElse(s"${keyPrefix}table", s"${tbl}_local")
+      val localSettingsClause = settingsClause(s"${keyPrefix}settings.")
+      createTable(Some(cluster), localEngineExpr, localDatabase, localTable, localSettingsClause)
+      createDistributedTable(cluster, shardExpr, localDatabase, localTable, db, tbl, settingsClause)
+    } else {
+      val settingsClause = settingsClause(s"${keyPrefix}settings.")
+      createTable(clusterOpt, engineExpr, db, tbl, settingsClause)
+    }
 
     loadTable(ident)
   }

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/SchemaUtils.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/SchemaUtils.scala
@@ -77,6 +77,8 @@ object SchemaUtils {
       case FloatType => "Float32"
       case DoubleType => "Float64"
       case StringType => "String"
+      case VarcharType(_) => "String"
+      case CharType(_) => "String" // TODO: maybe FixString?
       case DateType => "Date"
       case TimestampType => "DateTime"
       case ArrayType(elemType, nullable) => s"Array(${maybeNullable(toClickHouseType(elemType), nullable)})"


### PR DESCRIPTION
Example:
```
CREATE TABLE db.tbl_dist (
  create_time TIMESTAMP NOT NULL,
  y           INT       NOT NULL COMMENT 'shard key',
  m           INT       NOT NULL COMMENT 'part key',
  id          BIGINT    NOT NULL COMMENT 'sort key',
  value       STRING
) USING ClickHouse
PARTITIONED BY (m)
TBLPROPERTIES (
  cluster = 'cluster',
  engine = 'Distributed',
  shard_by = 'y',
  local.engine = 'MergeTree()',
  local.database = 'db',
  local.table = 'tbl_local',
  local.order_by = 'id',
  local.settings.index_granularity = 8192
)
```