### PR TITLE
Make repartition/local sort by partitions optional

### DIFF
--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -80,6 +80,12 @@ SQL Configurations
     Description: When reading Distributed table, read local table instead of itself. If `true`, ignore
                  `read.distributed.useClusterNodes`.
 
+!!! tip "Since 0.3.0 - spark.clickhouse.write.localSortByPartition"
+
+    Default Value: `spark.clickhouse.write.repartitionByPartition`
+
+    Description: If `true`, do local sort by partition before writing.
+
 !!! tip "Since 0.3.0 - spark.clickhouse.write.localSortByKey"
 
     Default Value: true

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -47,6 +47,13 @@ SQL Configurations
     Description: Repartition data to meet the distributions of ClickHouse table is required before writing, use this
                  conf to specific the repartition number, value less than 1 mean no requirement.
 
+!!! tip "Since 0.3.0 - spark.clickhouse.write.repartitionByPartition"
+
+    Default Value: true
+
+    Description: Whether to repartition data by ClickHouse partition keys to meet the distributions of ClickHouse table
+                 before writing.
+
 !!! tip "Since 0.1.0 - spark.clickhouse.write.distributed.useClusterNodes"
 
     Default Value: true

--- a/spark-3.2/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
+++ b/spark-3.2/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
@@ -25,16 +25,59 @@ import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
 import xenon.clickhouse.Logging
 import xenon.clickhouse.base.ClickHouseSingleMixIn
 
-class LocalSortByKeySuite extends BaseSparkSuite
-  with ClickHouseSingleMixIn
-  with SparkClickHouseSingleMixin
-  with SparkClickHouseSingleTestHelper
-  with Logging {
+class WriteDistributionAndOrderingSuite extends BaseSparkSuite
+    with ClickHouseSingleMixIn
+    with SparkClickHouseSingleMixin
+    with SparkClickHouseSingleTestHelper
+    with Logging {
 
   import spark.implicits._
 
+  test("write repartitionByPartition") {
+    autoCleanupTable("db_repartitionByPartition", "tbl_repartitionByPartition") { (db, tbl) =>
+      runClickHouseSQL(
+        s"""CREATE TABLE `$db`.`$tbl` (
+           |    `id` String,
+           |    `load_date` Date
+           |) ENGINE = MergeTree
+           |ORDER BY load_date
+           |PARTITION BY xxHash64(id)
+           |""".stripMargin
+      )
+      import org.apache.spark.sql.functions._
+
+      spark.sessionState.conf.setConf(WRITE_REPARTITION_BY_PARTITION, true)
+      intercept[AnalysisException] {
+        spark.range(3)
+          .toDF("id")
+          .withColumn("id", $"id".cast(StringType))
+          .withColumn("load_date", lit(LocalDate.of(2022, 5, 27)))
+          .writeTo(s"$db.$tbl")
+          .append
+      }
+
+      spark.sessionState.conf.setConf(WRITE_REPARTITION_BY_PARTITION, false)
+      spark.range(3)
+        .toDF("id")
+        .withColumn("id", $"id".cast(StringType))
+        .withColumn("load_date", lit(LocalDate.of(2022, 5, 27)))
+        .writeTo(s"$db.$tbl")
+        .append
+
+      checkAnswer(
+        spark.sql(s"SELECT id, load_date FROM $db.$tbl"),
+        Seq(
+          Row("0", Date.valueOf("2022-05-27")),
+          Row("1", Date.valueOf("2022-05-27")),
+          Row("2", Date.valueOf("2022-05-27"))
+        )
+      )
+      spark.sessionState.conf.unsetConf(WRITE_REPARTITION_BY_PARTITION)
+    }
+  }
+
   test("write localSortByKey") {
-    autoCleanupTable("db_sort", "tbl_sort") { (db, tbl) =>
+    autoCleanupTable("db_localSortByKey", "tbl_localSortByKey") { (db, tbl) =>
       runClickHouseSQL(
         s"""CREATE TABLE `$db`.`$tbl` (
            |    `id` String,
@@ -42,7 +85,6 @@ class LocalSortByKeySuite extends BaseSparkSuite
            |) ENGINE = MergeTree
            |ORDER BY xxHash64(id)
            |PARTITION BY load_date
-           |SAMPLE BY xxHash64(id)
            |""".stripMargin
       )
       import org.apache.spark.sql.functions._
@@ -56,6 +98,7 @@ class LocalSortByKeySuite extends BaseSparkSuite
           .writeTo(s"$db.$tbl")
           .append
       }
+
       spark.sessionState.conf.setConf(WRITE_LOCAL_SORT_BY_KEY, false)
       spark.range(3)
         .toDF("id")
@@ -72,7 +115,7 @@ class LocalSortByKeySuite extends BaseSparkSuite
           Row("2", Date.valueOf("2022-05-27"))
         )
       )
-      spark.sessionState.conf.clear()
+      spark.sessionState.conf.unsetConf(WRITE_LOCAL_SORT_BY_KEY)
     }
   }
 }

--- a/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -65,6 +65,14 @@ object ClickHouseSQLConf {
       .intConf
       .createWithDefault(0)
 
+  val WRITE_REPARTITION_BY_PARTITION: ConfigEntry[Boolean] =
+    buildConf(WRITE_REPARTITION_BY_PARTITION_KEY)
+      .doc("Whether to repartition data by ClickHouse partition keys to meet the distributions of " +
+        "ClickHouse table before writing.")
+      .version("0.3.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES: ConfigEntry[Boolean] =
     buildConf(WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY)
       .doc("Write to all nodes of cluster when writing Distributed table.")

--- a/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -104,6 +104,12 @@ object ClickHouseSQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val WRITE_LOCAL_SORT_BY_PARTITION: ConfigEntry[Boolean] =
+    buildConf(WRITE_LOCAL_SORT_BY_PARTITION_KEY)
+      .doc("If `true`, do local sort by partition before writing.")
+      .version("0.3.0")
+      .fallbackConf(WRITE_REPARTITION_BY_PARTITION)
+
   val WRITE_LOCAL_SORT_BY_KEY: ConfigEntry[Boolean] =
     buildConf(WRITE_LOCAL_SORT_BY_KEY_KEY)
       .doc("If `true`, do local sort by sort keys before writing.")

--- a/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
@@ -32,6 +32,7 @@ object SparkOptions {
   val WRITE_RETRY_INTERVAL_KEY: String = "write.retryInterval"
   val WRITE_RETRYABLE_ERROR_CODES_KEY: String = "write.retryableErrorCodes"
   val WRITE_REPARTITION_NUM_KEY: String = "write.repartitionNum"
+  val WRITE_REPARTITION_BY_PARTITION_KEY: String = "write.repartitionByPartition"
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY: String = "write.distributed.useClusterNodes"
   val WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY: String = "write.distributed.convertLocal"
   val WRITE_LOCAL_SORT_BY_KEY_KEY: String = "write.localSortByKey"
@@ -69,6 +70,9 @@ class WriteOptions(_options: JMap[String, String]) extends SparkOptions {
   def retryableErrorCodes: Seq[Int] = eval(WRITE_RETRYABLE_ERROR_CODES_KEY, WRITE_RETRYABLE_ERROR_CODES)
 
   def repartitionNum: Int = eval(WRITE_REPARTITION_NUM_KEY, WRITE_REPARTITION_NUM)
+
+  def repartitionByPartition: Boolean =
+    eval(WRITE_REPARTITION_BY_PARTITION_KEY, WRITE_REPARTITION_BY_PARTITION)
 
   def useClusterNodesForDistributed: Boolean =
     eval(WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY, WRITE_DISTRIBUTED_USE_CLUSTER_NODES)

--- a/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
@@ -35,6 +35,7 @@ object SparkOptions {
   val WRITE_REPARTITION_BY_PARTITION_KEY: String = "write.repartitionByPartition"
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY: String = "write.distributed.useClusterNodes"
   val WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY: String = "write.distributed.convertLocal"
+  val WRITE_LOCAL_SORT_BY_PARTITION_KEY: String = "write.localSortByPartition"
   val WRITE_LOCAL_SORT_BY_KEY_KEY: String = "write.localSortByKey"
 }
 
@@ -79,6 +80,9 @@ class WriteOptions(_options: JMap[String, String]) extends SparkOptions {
 
   def convertDistributedToLocal: Boolean =
     eval(WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY, WRITE_DISTRIBUTED_CONVERT_LOCAL)
+
+  def localSortByPartition: Boolean =
+    eval(WRITE_LOCAL_SORT_BY_PARTITION_KEY, WRITE_LOCAL_SORT_BY_PARTITION)
 
   def localSortByKey: Boolean =
     eval(WRITE_LOCAL_SORT_BY_KEY_KEY, WRITE_LOCAL_SORT_BY_KEY)

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
@@ -58,7 +58,12 @@ case class WriteJobDescription(
     case _ => None
   }
 
-  def sparkSplits: Array[Transform] = ExprUtils.toSparkSplits(shardingKeyIgnoreRand, partitionKey)
+  def sparkSplits: Array[Transform] =
+    if (writeOptions.repartitionByPartition) {
+      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, partitionKey)
+    } else {
+      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, None)
+    }
 
   def sparkSortOrders: Array[SortOrder] =
     if (writeOptions.localSortByKey) {

--- a/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
+++ b/spark-3.2/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
@@ -65,10 +65,9 @@ case class WriteJobDescription(
       ExprUtils.toSparkSplits(shardingKeyIgnoreRand, None)
     }
 
-  def sparkSortOrders: Array[SortOrder] =
-    if (writeOptions.localSortByKey) {
-      ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, partitionKey, sortingKey)
-    } else {
-      ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, partitionKey, None)
-    }
+  def sparkSortOrders: Array[SortOrder] = {
+    val _partitionKey = if (writeOptions.localSortByPartition) partitionKey else None
+    val _sortingKey = if (writeOptions.localSortByKey) sortingKey else None
+    ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, _partitionKey, _sortingKey)
+  }
 }

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
 import xenon.clickhouse.Logging
 import xenon.clickhouse.base.ClickHouseSingleMixIn
 
-class LocalSortByKeySuite extends BaseSparkSuite
+class WriteDistributionAndOrderingSuite extends BaseSparkSuite
     with ClickHouseSingleMixIn
     with SparkClickHouseSingleMixin
     with SparkClickHouseSingleTestHelper
@@ -33,8 +33,51 @@ class LocalSortByKeySuite extends BaseSparkSuite
 
   import spark.implicits._
 
+  test("write repartitionByPartition") {
+    autoCleanupTable("db_repartitionByPartition", "tbl_repartitionByPartition") { (db, tbl) =>
+      runClickHouseSQL(
+        s"""CREATE TABLE `$db`.`$tbl` (
+           |    `id` String,
+           |    `load_date` Date
+           |) ENGINE = MergeTree
+           |ORDER BY load_date
+           |PARTITION BY xxHash64(id)
+           |""".stripMargin
+      )
+      import org.apache.spark.sql.functions._
+
+      spark.sessionState.conf.setConf(WRITE_REPARTITION_BY_PARTITION, true)
+      // SPARK-39313
+      // intercept[AnalysisException] {
+      //   spark.range(3)
+      //     .toDF("id")
+      //     .withColumn("id", $"id".cast(StringType))
+      //     .withColumn("load_date", lit(LocalDate.of(2022, 5, 27)))
+      //     .writeTo(s"$db.$tbl")
+      //     .append
+      // }
+      spark.sessionState.conf.setConf(WRITE_REPARTITION_BY_PARTITION, false)
+      spark.range(3)
+        .toDF("id")
+        .withColumn("id", $"id".cast(StringType))
+        .withColumn("load_date", lit(LocalDate.of(2022, 5, 27)))
+        .writeTo(s"$db.$tbl")
+        .append
+
+      checkAnswer(
+        spark.sql(s"SELECT id, load_date FROM $db.$tbl"),
+        Seq(
+          Row("0", Date.valueOf("2022-05-27")),
+          Row("1", Date.valueOf("2022-05-27")),
+          Row("2", Date.valueOf("2022-05-27"))
+        )
+      )
+      spark.sessionState.conf.unsetConf(WRITE_REPARTITION_BY_PARTITION)
+    }
+  }
+
   test("write localSortByKey") {
-    autoCleanupTable("db_sort", "tbl_sort") { (db, tbl) =>
+    autoCleanupTable("db_localSortByKey", "tbl_localSortByKey") { (db, tbl) =>
       runClickHouseSQL(
         s"""CREATE TABLE `$db`.`$tbl` (
            |    `id` String,
@@ -42,7 +85,6 @@ class LocalSortByKeySuite extends BaseSparkSuite
            |) ENGINE = MergeTree
            |ORDER BY xxHash64(id)
            |PARTITION BY load_date
-           |SAMPLE BY xxHash64(id)
            |""".stripMargin
       )
       import org.apache.spark.sql.functions._
@@ -73,7 +115,7 @@ class LocalSortByKeySuite extends BaseSparkSuite
           Row("2", Date.valueOf("2022-05-27"))
         )
       )
-      spark.sessionState.conf.clear()
+      spark.sessionState.conf.unsetConf(WRITE_LOCAL_SORT_BY_KEY)
     }
   }
 }

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/WriteDistributionAndOrderingSuite.scala
@@ -56,6 +56,7 @@ class WriteDistributionAndOrderingSuite extends BaseSparkSuite
       //     .writeTo(s"$db.$tbl")
       //     .append
       // }
+
       spark.sessionState.conf.setConf(WRITE_REPARTITION_BY_PARTITION, false)
       spark.range(3)
         .toDF("id")
@@ -99,6 +100,7 @@ class WriteDistributionAndOrderingSuite extends BaseSparkSuite
       //     .writeTo(s"$db.$tbl")
       //     .append
       // }
+
       spark.sessionState.conf.setConf(WRITE_LOCAL_SORT_BY_KEY, false)
       spark.range(3)
         .toDF("id")

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -65,6 +65,14 @@ object ClickHouseSQLConf {
       .intConf
       .createWithDefault(0)
 
+  val WRITE_REPARTITION_BY_PARTITION: ConfigEntry[Boolean] =
+    buildConf(WRITE_REPARTITION_BY_PARTITION_KEY)
+      .doc("Whether to repartition data by ClickHouse partition keys to meet the distributions of " +
+        "ClickHouse table before writing.")
+      .version("0.3.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES: ConfigEntry[Boolean] =
     buildConf(WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY)
       .doc("Write to all nodes of cluster when writing Distributed table.")

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -104,6 +104,12 @@ object ClickHouseSQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val WRITE_LOCAL_SORT_BY_PARTITION: ConfigEntry[Boolean] =
+    buildConf(WRITE_LOCAL_SORT_BY_PARTITION_KEY)
+      .doc("If `true`, do local sort by partition before writing.")
+      .version("0.3.0")
+      .fallbackConf(WRITE_REPARTITION_BY_PARTITION)
+
   val WRITE_LOCAL_SORT_BY_KEY: ConfigEntry[Boolean] =
     buildConf(WRITE_LOCAL_SORT_BY_KEY_KEY)
       .doc("If `true`, do local sort by sort keys before writing.")

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
@@ -32,6 +32,7 @@ object SparkOptions {
   val WRITE_RETRY_INTERVAL_KEY: String = "write.retryInterval"
   val WRITE_RETRYABLE_ERROR_CODES_KEY: String = "write.retryableErrorCodes"
   val WRITE_REPARTITION_NUM_KEY: String = "write.repartitionNum"
+  val WRITE_REPARTITION_BY_PARTITION_KEY: String = "write.repartitionByPartition"
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY: String = "write.distributed.useClusterNodes"
   val WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY: String = "write.distributed.convertLocal"
   val WRITE_LOCAL_SORT_BY_KEY_KEY: String = "write.localSortByKey"
@@ -69,6 +70,9 @@ class WriteOptions(_options: JMap[String, String]) extends SparkOptions {
   def retryableErrorCodes: Seq[Int] = eval(WRITE_RETRYABLE_ERROR_CODES_KEY, WRITE_RETRYABLE_ERROR_CODES)
 
   def repartitionNum: Int = eval(WRITE_REPARTITION_NUM_KEY, WRITE_REPARTITION_NUM)
+
+  def repartitionByPartition: Boolean =
+    eval(WRITE_REPARTITION_BY_PARTITION_KEY, WRITE_REPARTITION_BY_PARTITION)
 
   def useClusterNodesForDistributed: Boolean =
     eval(WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY, WRITE_DISTRIBUTED_USE_CLUSTER_NODES)

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SparkOptions.scala
@@ -35,6 +35,7 @@ object SparkOptions {
   val WRITE_REPARTITION_BY_PARTITION_KEY: String = "write.repartitionByPartition"
   val WRITE_DISTRIBUTED_USE_CLUSTER_NODES_KEY: String = "write.distributed.useClusterNodes"
   val WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY: String = "write.distributed.convertLocal"
+  val WRITE_LOCAL_SORT_BY_PARTITION_KEY: String = "write.localSortByPartition"
   val WRITE_LOCAL_SORT_BY_KEY_KEY: String = "write.localSortByKey"
 }
 
@@ -79,6 +80,9 @@ class WriteOptions(_options: JMap[String, String]) extends SparkOptions {
 
   def convertDistributedToLocal: Boolean =
     eval(WRITE_DISTRIBUTED_CONVERT_LOCAL_KEY, WRITE_DISTRIBUTED_CONVERT_LOCAL)
+
+  def localSortByPartition: Boolean =
+    eval(WRITE_LOCAL_SORT_BY_PARTITION_KEY, WRITE_LOCAL_SORT_BY_PARTITION)
 
   def localSortByKey: Boolean =
     eval(WRITE_LOCAL_SORT_BY_KEY_KEY, WRITE_LOCAL_SORT_BY_KEY)

--- a/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
@@ -58,7 +58,12 @@ case class WriteJobDescription(
     case _ => None
   }
 
-  def sparkSplits: Array[Transform] = ExprUtils.toSparkSplits(shardingKeyIgnoreRand, partitionKey)
+  def sparkSplits: Array[Transform] =
+    if (writeOptions.repartitionByPartition) {
+      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, partitionKey)
+    } else {
+      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, None)
+    }
 
   def sparkSortOrders: Array[SortOrder] =
     if (writeOptions.localSortByKey) {

--- a/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/write/WriteJobDescription.scala
@@ -65,10 +65,9 @@ case class WriteJobDescription(
       ExprUtils.toSparkSplits(shardingKeyIgnoreRand, None)
     }
 
-  def sparkSortOrders: Array[SortOrder] =
-    if (writeOptions.localSortByKey) {
-      ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, partitionKey, sortingKey)
-    } else {
-      ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, partitionKey, None)
-    }
+  def sparkSortOrders: Array[SortOrder] = {
+    val _partitionKey = if (writeOptions.localSortByPartition) partitionKey else None
+    val _sortingKey = if (writeOptions.localSortByKey) sortingKey else None
+    ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, _partitionKey, _sortingKey)
+  }
 }


### PR DESCRIPTION
Introduce two configurations to repartition/local sort by partitions optional 
- `spark.clickhouse.write.repartitionByPartition`
- `spark.clickhouse.write.localSortByPartition`