### PR TITLE
Test: Remove obsolete settings

### DIFF
--- a/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/users.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-cluster/users.xml
@@ -17,9 +17,6 @@
     <profiles>
         <!-- Default settings. -->
         <default>
-            <!-- Maximum memory usage for processing single query, in bytes. -->
-            <max_memory_usage>10000000000</max_memory_usage>
-
             <!-- How to choose between replicas during distributed query processing.
                  random - choose random replica from set of replicas with minimum number of errors
                  nearest_hostname - from set of replicas with minimum number of errors, choose replica
@@ -29,8 +26,6 @@
                  first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
-            <!-- Enable Map support -->
-            <allow_experimental_map_type>1</allow_experimental_map_type>
         </default>
 
         <!-- Profile that allows only read queries. -->

--- a/clickhouse-core/src/testFixtures/conf/clickhouse-single/users.xml
+++ b/clickhouse-core/src/testFixtures/conf/clickhouse-single/users.xml
@@ -17,9 +17,6 @@
     <profiles>
         <!-- Default settings. -->
         <default>
-            <!-- Maximum memory usage for processing single query, in bytes. -->
-            <max_memory_usage>10000000000</max_memory_usage>
-
             <!-- How to choose between replicas during distributed query processing.
                  random - choose random replica from set of replicas with minimum number of errors
                  nearest_hostname - from set of replicas with minimum number of errors, choose replica
@@ -29,8 +26,6 @@
                  first_or_random - if first replica one has higher number of errors, pick a random one from replicas with minimum number of errors.
             -->
             <load_balancing>random</load_balancing>
-            <!-- Enable Map support -->
-            <allow_experimental_map_type>1</allow_experimental_map_type>
         </default>
 
         <!-- Profile that allows only read queries. -->


### PR DESCRIPTION
Suppress warning

```
(scc) ➜  spark-clickhouse-connector git:(obsolete) docker exec -it clickhouse-s1r1 bash
bash-5.1# clickhouse-client -m
ClickHouse client version 22.5.1.1.
Connecting to localhost:9000 as user default.
Connected to ClickHouse server version 22.5.1 revision 54455.

Warnings:
 * Linux is not using fast TSC clock source. Performance can be degraded.
 * Some obsolete setting is changed. Check 'select * from system.settings where changed' and read the changelog.

clickhouse-s1r1 :)
```