### PR TITLE
Allow dropping partitions with Date type column

### DIFF
--- a/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
@@ -184,6 +184,7 @@ case class ClickHouseTable(
         case IntegerType => compileValue(ident.getInt(i))
         case LongType => compileValue(ident.getLong(i))
         case StringType => compileValue(ident.getUTF8String(i))
+        case DateType => compileValue(LocalDate.ofEpochDay(ident.getInt(i)))
         case illegal => throw new IllegalArgumentException(s"Illegal partition data type: $illegal")
       }
     }.mkString("(", ",", ")")


### PR DESCRIPTION
This pull request enables the `DROP PARTITION` operation to work with tables that have a column of type Date as partition. With this change, you can use a statement like the following to drop a partition from a ClickHouse table:

```
ALTER TABLE <table> DROP PARTITION (dt='2023-02-15')
```
where dt is a column with type Date. Before this change, attempting to drop a partition with a Date column would result in an error.

I've tested this change by running the `DROP PARTITION` operation on a table with a Date column, and I've verified that it works as expected.

Let me know if you have any questions or concerns about this change.