### PR TITLE
Spark 3.4: Fix custom options

### DIFF
--- a/clickhouse-core/src/main/scala/xenon/clickhouse/spec/NodeSpec.scala
+++ b/clickhouse-core/src/main/scala/xenon/clickhouse/spec/NodeSpec.scala
@@ -21,7 +21,7 @@ import xenon.clickhouse.ToJson
 import xenon.clickhouse.Utils._
 
 import java.util
-import scala.collection.JavaConverters._
+import java.util.Collections
 
 trait Nodes {
   def nodes: Array[NodeSpec]
@@ -36,7 +36,7 @@ case class NodeSpec(
   @JsonProperty("username") username: String = "default",
   @JsonProperty("password") password: String = "",
   @JsonProperty("database") database: String = "default",
-  @JsonProperty("options") options: util.Map[String, String] = Map.empty[String, String].asJava
+  @JsonProperty("options") options: util.Map[String, String] = Collections.emptyMap()
 ) extends Nodes with ToJson with Serializable {
   @JsonProperty("host") def host: String = findHost(_host)
   @JsonProperty("http_port") def http_port: Option[Int] = findPort(_http_port)

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-mavenCentralMirror=https://repo.maven.apache.org/maven2/
+mavenCentralMirror=https://mirrors.cloud.tencent.com/nexus/repository/maven-public/
 mavenSnapshotsRepo=https://oss.sonatype.org/content/repositories/snapshots/
 mavenReleasesRepo=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
@@ -29,6 +29,7 @@ import xenon.clickhouse.exception.CHException
 import xenon.clickhouse.spec._
 
 import java.time.{LocalDateTime, ZoneId}
+import java.util.{HashMap => JHashMap}
 import scala.collection.JavaConverters._
 
 trait ClickHouseHelper extends Logging {
@@ -54,7 +55,7 @@ trait ClickHouseHelper extends Logging {
           log.warn(s"Ignore configuration $key.")
         }
         !ignore
-      }.toMap
+      }
     NodeSpec(
       _host = options.getOrDefault(CATALOG_PROP_HOST, "localhost"),
       _grpc_port = Some(options.getInt(CATALOG_PROP_GRPC_PORT, 9100)),
@@ -64,7 +65,7 @@ trait ClickHouseHelper extends Logging {
       username = options.getOrDefault(CATALOG_PROP_USER, "default"),
       password = options.getOrDefault(CATALOG_PROP_PASSWORD, ""),
       database = options.getOrDefault(CATALOG_PROP_DATABASE, "default"),
-      options = clientOpts.asJava
+      options = new JHashMap(clientOpts.asJava)
     )
   }
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
@@ -47,9 +47,9 @@ trait ClickHouseHelper extends Logging {
   def buildNodeSpec(options: CaseInsensitiveStringMap): NodeSpec = {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))
+      .map { case (k, v) => k.substring(CATALOG_PROP_OPTION_PREFIX.length) -> v }
       .filterKeys { key =>
-        val clientOpt = key.substring(CATALOG_PROP_OPTION_PREFIX.length)
-        val ignore = CATALOG_PROP_IGNORE_OPTIONS.contains(clientOpt)
+        val ignore = CATALOG_PROP_IGNORE_OPTIONS.contains(key)
         if (ignore) {
           log.warn(s"Ignore configuration $key.")
         }

--- a/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseHelper.scala
@@ -49,6 +49,7 @@ trait ClickHouseHelper extends Logging {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))
       .map { case (k, v) => k.substring(CATALOG_PROP_OPTION_PREFIX.length) -> v }
+      .toMap
       .filterKeys { key =>
         val ignore = CATALOG_PROP_IGNORE_OPTIONS.contains(key)
         if (ignore) {
@@ -56,6 +57,7 @@ trait ClickHouseHelper extends Logging {
         }
         !ignore
       }
+      .toMap
     NodeSpec(
       _host = options.getOrDefault(CATALOG_PROP_HOST, "localhost"),
       _grpc_port = Some(options.getInt(CATALOG_PROP_GRPC_PORT, 9100)),

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+import xenon.clickhouse.ClickHouseHelper
+
+import scala.collection.JavaConverters._
+
+class ClickHouseHelperSuite extends AnyFunSuite with ClickHouseHelper {
+
+  test("buildNodeSpec") {
+    val nodeSpec = buildNodeSpec(
+      new CaseInsensitiveStringMap(Map(
+        "database" -> "testing",
+        "option.database" -> "production",
+        "option.ssl" -> "true"
+      ).asJava)
+    )
+    assert(nodeSpec.database === "testing")
+    assert(nodeSpec.options.get("ssl") === "true")
+  }
+}


### PR DESCRIPTION
Fix #230, this is for Spark 3.4, will backport to Spark 3.3 in another PR