### PR TITLE
Spark 3.4: Adapt to SPARK-43390 to allow reserving schema nullability on CTAS/RTAS

### DIFF
--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -21,6 +21,7 @@ spark.clickhouse.read.compression.codec|lz4|The codec used to decompress data fo
 spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed table, read local table instead of itself. If `true`, ignore `spark.clickhouse.read.distributed.useClusterNodes`.|0.1.0
 spark.clickhouse.read.format|json|Serialize format for reading. Supported formats: json, binary|0.6.0
 spark.clickhouse.read.splitByPartitionId|true|If `true`, construct input partition filter by virtual column `_partition_id`, instead of partition value. There are known bugs to assemble SQL predication by partition value. This feature requires ClickHouse Server v21.6+|0.4.0
+spark.clickhouse.useNullableQuerySchema|false|If `true`, mark all the fields of the query schema as nullable when executing `CREATE/REPLACE TABLE ... AS SELECT ...` and creating the table. Note, this configuration requires SPARK-43390(available in Spark 3.5), w/o this patch, it always acts as `true`.|0.8.0
 spark.clickhouse.write.batchSize|10000|The number of records per batch on writing to ClickHouse.|0.1.0
 spark.clickhouse.write.compression.codec|lz4|The codec used to compress data for writing. Supported codecs: none, lz4.|0.3.0
 spark.clickhouse.write.distributed.convertLocal|false|When writing Distributed table, write local table instead of itself. If `true`, ignore `spark.clickhouse.write.distributed.useClusterNodes`.|0.1.0
@@ -31,7 +32,7 @@ spark.clickhouse.write.localSortByPartition|<value of spark.clickhouse.write.rep
 spark.clickhouse.write.maxRetry|3|The maximum number of write we will retry for a single batch write failed with retryable codes.|0.1.0
 spark.clickhouse.write.repartitionByPartition|true|Whether to repartition data by ClickHouse partition keys to meet the distributions of ClickHouse table before writing.|0.3.0
 spark.clickhouse.write.repartitionNum|0|Repartition data to meet the distributions of ClickHouse table is required before writing, use this conf to specific the repartition number, value less than 1 mean no requirement.|0.1.0
-spark.clickhouse.write.repartitionStrictly|false|If `true`, Spark will strictly distribute incoming records across partitions to satisfy the required distribution before passing the records to the data source table on write. Otherwise, Spark may apply certain optimizations to speed up the query but break the distribution requirement. Note, this configuration requires SPARK-37523(available in Spark 3.4), w/o this patch, it always act as `true`.|0.3.0
+spark.clickhouse.write.repartitionStrictly|false|If `true`, Spark will strictly distribute incoming records across partitions to satisfy the required distribution before passing the records to the data source table on write. Otherwise, Spark may apply certain optimizations to speed up the query but break the distribution requirement. Note, this configuration requires SPARK-37523(available in Spark 3.4), w/o this patch, it always acts as `true`.|0.3.0
 spark.clickhouse.write.retryInterval|10s|The interval in seconds between write retry.|0.1.0
 spark.clickhouse.write.retryableErrorCodes|241|The retryable error codes returned by ClickHouse server when write failing.|0.1.0
 <!--end-include-->

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -80,7 +80,7 @@ object ClickHouseSQLConf {
         "the required distribution before passing the records to the data source table on write. " +
         "Otherwise, Spark may apply certain optimizations to speed up the query but break the " +
         "distribution requirement. Note, this configuration requires SPARK-37523(available in " +
-        "Spark 3.4), w/o this patch, it always act as `true`.")
+        "Spark 3.4), w/o this patch, it always acts as `true`.")
       .version("0.3.0")
       .booleanConf
       .createWithDefault(false)
@@ -184,4 +184,14 @@ object ClickHouseSQLConf {
         case s => s.toLowerCase
       }
       .createWithDefault("arrow")
+
+  val USE_NULLABLE_QUERY_SCHEMA: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.useNullableQuerySchema")
+      .doc("If `true`, mark all the fields of the query schema as nullable when executing " +
+        "`CREATE/REPLACE TABLE ... AS SELECT ...` and creating the table. Note, this " +
+        "configuration requires SPARK-43390(available in Spark 3.5), w/o this patch, " +
+        "it always acts as `true`.")
+      .version("0.8.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
@@ -17,13 +17,11 @@ package xenon.clickhouse
 import java.lang.{Integer => JInt, Long => JLong}
 import java.time.{LocalDate, ZoneId}
 import java.util
-
 import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -95,6 +93,9 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
+
+  // for SPARK-43390
+  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(


### PR DESCRIPTION
Fix https://github.com/housepower/spark-clickhouse-connector/issues/167
Fix https://github.com/housepower/spark-clickhouse-connector/issues/236