### PR TITLE
Spark 3.3: Adapt to SPARK-43390 to allow reserving schema nullability on CTAS/RTAS

### DIFF
--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -80,7 +80,7 @@ object ClickHouseSQLConf {
         "the required distribution before passing the records to the data source table on write. " +
         "Otherwise, Spark may apply certain optimizations to speed up the query but break the " +
         "distribution requirement. Note, this configuration requires SPARK-37523(available in " +
-        "Spark 3.4), w/o this patch, it always act as `true`.")
+        "Spark 3.4), w/o this patch, it always acts as `true`.")
       .version("0.3.0")
       .booleanConf
       .createWithDefault(false)
@@ -184,4 +184,14 @@ object ClickHouseSQLConf {
         case s => s.toLowerCase
       }
       .createWithDefault("arrow")
+
+  val USE_NULLABLE_QUERY_SCHEMA: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.useNullableQuerySchema")
+      .doc("If `true`, mark all the fields of the query schema as nullable when executing " +
+        "`CREATE/REPLACE TABLE ... AS SELECT ...` and creating the table. Note, this " +
+        "configuration requires SPARK-43390(available in Spark 3.5), w/o this patch, " +
+        "it always acts as `true`.")
+      .version("0.8.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/xenon/clickhouse/ClickHouseTable.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -95,6 +95,9 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
+
+  // for SPARK-43390
+  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(


### PR DESCRIPTION
Backport #237 to Spark 3.3