### PR TITLE
Spark 3.4: ClickHouse FixedString map to Spark BinaryType

### DIFF
--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -25,7 +25,8 @@ object SchemaUtils {
     val catalystType = chColumn.getDataType match {
       case Nothing => NullType
       case Bool => BooleanType
-      case String | FixedString | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
+      case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
+      case FixedString => BinaryType
       case Int8 => ByteType
       case UInt8 | Int16 => ShortType
       case UInt16 | Int32 => IntegerType

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/SchemaUtilsSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/SchemaUtilsSuite.scala
@@ -160,7 +160,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
     ),
     TestBean(
       "FixedString(5)",
-      StringType,
+      BinaryType,
       nullable = false
     ),
     TestBean(
@@ -170,7 +170,7 @@ class SchemaUtilsSuite extends AnyFunSuite {
     ),
     TestBean(
       "LowCardinality(FixedString(5))",
-      StringType,
+      BinaryType,
       nullable = false
     ),
     TestBean(


### PR DESCRIPTION
Fix #250