### PR TITLE
Build: Bump testcontainers-scala 0.41.0 to support Docker Compose v2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,6 @@ jakarta_annotation_api_version=1.3.5
 
 # Test only
 kyuubi_version=1.7.1
-testcontainers_scala_version=0.40.12
+testcontainers_scala_version=0.41.0
 scalatest_version=3.2.15
 flexmark_version=0.62.2


### PR DESCRIPTION
This upgrading allows the developers to run docker compose related tests without the legacy `docker-compose` command in the `PATH`

https://github.com/testcontainers/testcontainers-scala/pull/260