### PR TITLE
Spark: Make FixedString type mapping configurable

### DIFF
--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -16,6 +16,7 @@ license: |
 <!--begin-include-->
 |Key | Default | Description | Since
 |--- | ------- | ----------- | -----
+spark.clickhouse.fixedStringReadAs|binary|read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string|0.8.1
 spark.clickhouse.ignoreUnsupportedTransform|false|ClickHouse supports using complex expressions as sharding keys or partition values, e.g. `cityHash64(col_1, col_2)`, and those can not be supported by Spark now. If `true`, ignore the unsupported expressions, otherwise fail fast w/ an exception. Note, when `spark.clickhouse.write.distributed.convertLocal` is enabled, ignore unsupported sharding keys may corrupt the data.|0.4.0
 spark.clickhouse.read.compression.codec|lz4|The codec used to decompress data for reading. Supported codecs: none, lz4.|0.5.0
 spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed table, read local table instead of itself. If `true`, ignore `spark.clickhouse.read.distributed.useClusterNodes`.|0.1.0

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -16,10 +16,10 @@ license: |
 <!--begin-include-->
 |Key | Default | Description | Since
 |--- | ------- | ----------- | -----
-spark.clickhouse.fixedStringReadAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.ignoreUnsupportedTransform|false|ClickHouse supports using complex expressions as sharding keys or partition values, e.g. `cityHash64(col_1, col_2)`, and those can not be supported by Spark now. If `true`, ignore the unsupported expressions, otherwise fail fast w/ an exception. Note, when `spark.clickhouse.write.distributed.convertLocal` is enabled, ignore unsupported sharding keys may corrupt the data.|0.4.0
 spark.clickhouse.read.compression.codec|lz4|The codec used to decompress data for reading. Supported codecs: none, lz4.|0.5.0
 spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed table, read local table instead of itself. If `true`, ignore `spark.clickhouse.read.distributed.useClusterNodes`.|0.1.0
+spark.clickhouse.read.fixedStringAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.read.format|json|Serialize format for reading. Supported formats: json, binary|0.6.0
 spark.clickhouse.read.runtimeFilter.enabled|false|Enable runtime filter for reading.|0.8.0
 spark.clickhouse.read.splitByPartitionId|true|If `true`, construct input partition filter by virtual column `_partition_id`, instead of partition value. There are known bugs to assemble SQL predication by partition value. This feature requires ClickHouse Server v21.6+|0.4.0

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -16,7 +16,7 @@ license: |
 <!--begin-include-->
 |Key | Default | Description | Since
 |--- | ------- | ----------- | -----
-spark.clickhouse.fixedStringReadAs|binary|read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string|0.8.1
+spark.clickhouse.fixedStringReadAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.ignoreUnsupportedTransform|false|ClickHouse supports using complex expressions as sharding keys or partition values, e.g. `cityHash64(col_1, col_2)`, and those can not be supported by Spark now. If `true`, ignore the unsupported expressions, otherwise fail fast w/ an exception. Note, when `spark.clickhouse.write.distributed.convertLocal` is enabled, ignore unsupported sharding keys may corrupt the data.|0.4.0
 spark.clickhouse.read.compression.codec|lz4|The codec used to decompress data for reading. Supported codecs: none, lz4.|0.5.0
 spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed table, read local table instead of itself. If `true`, ignore `spark.clickhouse.read.distributed.useClusterNodes`.|0.1.0

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Run the following command to update the configuration docs.
- * UPDATE=1 ./gradlew test --tests=ConfigurationSuite
+ *   UPDATE=1 ./gradlew test --tests=ConfigurationSuite
  */
 object ClickHouseSQLConf {
 
@@ -204,8 +204,8 @@ object ClickHouseSQLConf {
 
   val FIXED_STRING_READ_AS: ConfigEntry[String] =
     buildConf("spark.clickhouse.fixedStringReadAs")
-      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
-      .version("0.8.1")
+      .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
+      .version("0.8.0")
       .stringConf
       .transform(_.toLowerCase)
       .createWithDefault("binary")

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Run the following command to update the configuration docs.
- *   UPDATE=1 ./gradlew test --tests=ConfigurationSuite
+ * UPDATE=1 ./gradlew test --tests=ConfigurationSuite
  */
 object ClickHouseSQLConf {
 
@@ -201,4 +201,12 @@ object ClickHouseSQLConf {
       .version("0.8.0")
       .booleanConf
       .createWithDefault(false)
+
+  val FIXED_STRING_READ_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.fixedStringReadAs")
+      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
+      .version("0.8.1")
+      .stringConf
+      .transform(_.toLowerCase)
+      .createWithDefault("binary")
 }

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -202,8 +202,8 @@ object ClickHouseSQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val FIXED_STRING_READ_AS: ConfigEntry[String] =
-    buildConf("spark.clickhouse.fixedStringReadAs")
+  val READ_FIXED_STRING_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.read.fixedStringAs")
       .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
       .version("0.8.0")
       .stringConf

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -19,7 +19,7 @@ import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_FIXED_STRING_AS
 
 object SchemaUtils extends SQLConfHelper {
 
@@ -29,7 +29,7 @@ object SchemaUtils extends SQLConfHelper {
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
       case FixedString =>
-        conf.getConf(FIXED_STRING_READ_AS) match {
+        conf.getConf(READ_FIXED_STRING_AS) match {
           case "binary" => BinaryType
           case "string" => StringType
           case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -18,15 +18,22 @@ import com.clickhouse.data.ClickHouseDataType._
 import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
 
-object SchemaUtils {
+object SchemaUtils extends SQLConfHelper {
 
   def fromClickHouseType(chColumn: ClickHouseColumn): (DataType, Boolean) = {
     val catalystType = chColumn.getDataType match {
       case Nothing => NullType
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
-      case FixedString => BinaryType
+      case FixedString =>
+        conf.getConf(FIXED_STRING_READ_AS) match {
+          case "binary" => BinaryType
+          case "string" => StringType
+          case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")
+        }
       case Int8 => ByteType
       case UInt8 | Int16 => ShortType
       case UInt16 | Int32 => IntegerType

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -202,8 +202,8 @@ object ClickHouseSQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val FIXED_STRING_READ_AS: ConfigEntry[String] =
-    buildConf("spark.clickhouse.fixedStringReadAs")
+  val READ_FIXED_STRING_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.read.fixedStringAs")
       .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
       .version("0.8.0")
       .stringConf

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -201,4 +201,12 @@ object ClickHouseSQLConf {
       .version("0.8.0")
       .booleanConf
       .createWithDefault(false)
+
+  val FIXED_STRING_READ_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.fixedStringReadAs")
+      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
+      .version("0.8.1")
+      .stringConf
+      .transform(_.toLowerCase)
+      .createWithDefault("binary")
 }

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -204,8 +204,8 @@ object ClickHouseSQLConf {
 
   val FIXED_STRING_READ_AS: ConfigEntry[String] =
     buildConf("spark.clickhouse.fixedStringReadAs")
-      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
-      .version("0.8.1")
+      .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
+      .version("0.8.0")
       .stringConf
       .transform(_.toLowerCase)
       .createWithDefault("binary")

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -19,7 +19,7 @@ import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_FIXED_STRING_AS
 
 object SchemaUtils extends SQLConfHelper {
 
@@ -29,7 +29,7 @@ object SchemaUtils extends SQLConfHelper {
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
       case FixedString =>
-        conf.getConf(FIXED_STRING_READ_AS) match {
+        conf.getConf(READ_FIXED_STRING_AS) match {
           case "binary" => BinaryType
           case "string" => StringType
           case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -18,15 +18,22 @@ import com.clickhouse.data.ClickHouseDataType._
 import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
 
-object SchemaUtils {
+object SchemaUtils extends SQLConfHelper {
 
   def fromClickHouseType(chColumn: ClickHouseColumn): (DataType, Boolean) = {
     val catalystType = chColumn.getDataType match {
       case Nothing => NullType
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
-      case FixedString => BinaryType
+      case FixedString =>
+        conf.getConf(FIXED_STRING_READ_AS) match {
+          case "binary" => BinaryType
+          case "string" => StringType
+          case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")
+        }
       case Int8 => ByteType
       case UInt8 | Int16 => ShortType
       case UInt16 | Int32 => IntegerType

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -202,8 +202,8 @@ object ClickHouseSQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val FIXED_STRING_READ_AS: ConfigEntry[String] =
-    buildConf("spark.clickhouse.fixedStringReadAs")
+  val READ_FIXED_STRING_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.read.fixedStringAs")
       .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
       .version("0.8.0")
       .stringConf

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -201,4 +201,12 @@ object ClickHouseSQLConf {
       .version("0.8.0")
       .booleanConf
       .createWithDefault(false)
+
+  val FIXED_STRING_READ_AS: ConfigEntry[String] =
+    buildConf("spark.clickhouse.fixedStringReadAs")
+      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
+      .version("0.8.1")
+      .stringConf
+      .transform(_.toLowerCase)
+      .createWithDefault("binary")
 }

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -204,8 +204,8 @@ object ClickHouseSQLConf {
 
   val FIXED_STRING_READ_AS: ConfigEntry[String] =
     buildConf("spark.clickhouse.fixedStringReadAs")
-      .doc("read ClickHouse FixedString type as the specified Spark data type. Supported formats: binary, string")
-      .version("0.8.1")
+      .doc("Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string")
+      .version("0.8.0")
       .stringConf
       .transform(_.toLowerCase)
       .createWithDefault("binary")

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -19,7 +19,7 @@ import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_FIXED_STRING_AS
 
 object SchemaUtils extends SQLConfHelper {
 
@@ -29,7 +29,7 @@ object SchemaUtils extends SQLConfHelper {
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
       case FixedString =>
-        conf.getConf(FIXED_STRING_READ_AS) match {
+        conf.getConf(READ_FIXED_STRING_AS) match {
           case "binary" => BinaryType
           case "string" => StringType
           case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/SchemaUtils.scala
@@ -18,15 +18,22 @@ import com.clickhouse.data.ClickHouseDataType._
 import com.clickhouse.data.{ClickHouseColumn, ClickHouseDataType}
 import org.apache.spark.sql.types._
 import xenon.clickhouse.exception.CHClientException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.FIXED_STRING_READ_AS
 
-object SchemaUtils {
+object SchemaUtils extends SQLConfHelper {
 
   def fromClickHouseType(chColumn: ClickHouseColumn): (DataType, Boolean) = {
     val catalystType = chColumn.getDataType match {
       case Nothing => NullType
       case Bool => BooleanType
       case String | JSON | UUID | Enum8 | Enum16 | IPv4 | IPv6 => StringType
-      case FixedString => BinaryType
+      case FixedString =>
+        conf.getConf(FIXED_STRING_READ_AS) match {
+          case "binary" => BinaryType
+          case "string" => StringType
+          case unsupported => throw CHClientException(s"Unsupported fixed string read format mapping: $unsupported")
+        }
       case Int8 => ByteType
       case UInt8 | Int16 => ShortType
       case UInt16 | Int32 => IntegerType


### PR DESCRIPTION
Add a new configuration option `spark.clickhouse.fixedStringReadAs` to determine whether ClickHouse fixed strings should be mapped to Spark BinaryType or StringType.

[open issue here](https://github.com/housepower/spark-clickhouse-connector/issues/264)