### PR TITLE
fix: Handle FixedString as plain text in JSON reader

### DIFF
--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
@@ -85,7 +85,12 @@ class ClickHouseJsonReader(
         TimeUnit.SECONDS.toMicros(_instant.toEpochSecond) + TimeUnit.NANOSECONDS.toMicros(_instant.getNano())
       case StringType => UTF8String.fromString(jsonNode.asText)
       case DateType => LocalDate.parse(jsonNode.asText, dateFmt).toEpochDay.toInt
-      case BinaryType => jsonNode.binaryValue
+      case BinaryType if jsonNode.isTextual =>
+        // ClickHouse JSON format returns FixedString as plain text, not Base64
+        jsonNode.asText.getBytes("UTF-8")
+      case BinaryType =>
+        // True binary data is Base64 encoded in JSON format
+        jsonNode.binaryValue
       case ArrayType(_dataType, _nullable) =>
         val _structField = StructField(s"${structField.name}__array_element__", _dataType, _nullable)
         new GenericArrayData(jsonNode.asScala.map(decodeValue(_, _structField)))

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
@@ -85,7 +85,12 @@ class ClickHouseJsonReader(
         TimeUnit.SECONDS.toMicros(_instant.toEpochSecond) + TimeUnit.NANOSECONDS.toMicros(_instant.getNano())
       case StringType => UTF8String.fromString(jsonNode.asText)
       case DateType => LocalDate.parse(jsonNode.asText, dateFmt).toEpochDay.toInt
-      case BinaryType => jsonNode.binaryValue
+      case BinaryType if jsonNode.isTextual =>
+        // ClickHouse JSON format returns FixedString as plain text, not Base64
+        jsonNode.asText.getBytes("UTF-8")
+      case BinaryType =>
+        // True binary data is Base64 encoded in JSON format
+        jsonNode.binaryValue
       case ArrayType(_dataType, _nullable) =>
         val _structField = StructField(s"${structField.name}__array_element__", _dataType, _nullable)
         new GenericArrayData(jsonNode.asScala.map(decodeValue(_, _structField)))

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala
@@ -85,7 +85,12 @@ class ClickHouseJsonReader(
         TimeUnit.SECONDS.toMicros(_instant.toEpochSecond) + TimeUnit.NANOSECONDS.toMicros(_instant.getNano())
       case StringType => UTF8String.fromString(jsonNode.asText)
       case DateType => LocalDate.parse(jsonNode.asText, dateFmt).toEpochDay.toInt
-      case BinaryType => jsonNode.binaryValue
+      case BinaryType if jsonNode.isTextual =>
+        // ClickHouse JSON format returns FixedString as plain text, not Base64
+        jsonNode.asText.getBytes("UTF-8")
+      case BinaryType =>
+        // True binary data is Base64 encoded in JSON format
+        jsonNode.binaryValue
       case ArrayType(_dataType, _nullable) =>
         val _structField = StructField(s"${structField.name}__array_element__", _dataType, _nullable)
         new GenericArrayData(jsonNode.asScala.map(decodeValue(_, _structField)))


### PR DESCRIPTION
# Fix FixedString handling in JSON reader

## Problem

ClickHouse returns `FixedString` columns as plain text in JSON format, but the connector was attempting to decode them as Base64-encoded binary data. This caused `InvalidFormatException` when reading FixedString columns with JSON format.

## Root Cause

The `ClickHouseJsonReader` treated all `BinaryType` columns the same way, calling `jsonNode.binaryValue` which expects Base64-encoded data. However, ClickHouse's JSON format returns:
- **FixedString**: Plain text (e.g., `"hello"`)
- **True Binary**: Base64-encoded (e.g., `"aGVsbG8="`)

## Solution

Added pattern matching with guard to distinguish between textual and binary JSON nodes:

```scala
case BinaryType if jsonNode.isTextual =>
  // ClickHouse JSON format returns FixedString as plain text
  jsonNode.asText.getBytes("UTF-8")
case BinaryType =>
  // True binary data is Base64 encoded
  jsonNode.binaryValue
```

## Changes

Applied to all Spark versions:
- `spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala`
- `spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala`
- `spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/format/ClickHouseJsonReader.scala`

## Testing

The fix is validated by comprehensive test coverage in PR #[test-coverage-pr]:
- `ClickHouseReaderTestBase` includes FixedString tests
- Tests run for both Binary and JSON formats
- Test now passes: `decode BinaryType - FixedString`

