### PR TITLE
fix: Disable HTTP compression to workaround ClickHouse bug

### DIFF
--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/client/NodeClient.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/client/NodeClient.scala
@@ -92,6 +92,8 @@ class NodeClient(val nodeSpec: NodeSpec) extends AutoCloseable with Logging {
       ClickHouseClientOption.PRODUCT_NAME,
       userAgent
     )
+    .option(ClickHouseClientOption.COMPRESS, false)
+    .option(ClickHouseClientOption.DECOMPRESS, false)
     .nodeSelector(ClickHouseNodeSelector.of(node.getProtocol))
     .build()
 

--- a/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseSingleMixIn.scala
+++ b/clickhouse-core/src/testFixtures/scala/com/clickhouse/spark/base/ClickHouseSingleMixIn.scala
@@ -59,6 +59,16 @@ trait ClickHouseSingleMixIn extends AnyFunSuite with ForAllTestContainer with Cl
       ) {
         // TODO: remove this workaround after https://github.com/testcontainers/testcontainers-java/pull/5666
         override def getDriverClassName: String = "com.clickhouse.jdbc.ClickHouseDriver"
+
+        // Override JDBC URL to disable compression to workaround ClickHouse bug
+        override def getJdbcUrl: String = {
+          val baseUrl = super.getJdbcUrl
+          if (baseUrl.contains("?")) {
+            baseUrl + "&compress=0&decompress=0"
+          } else {
+            baseUrl + "?compress=0&decompress=0"
+          }
+        }
       }
         .withEnv("CLICKHOUSE_USER", CLICKHOUSE_USER)
         .withEnv("CLICKHOUSE_PASSWORD", CLICKHOUSE_PASSWORD)

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -17,7 +17,7 @@ license: |
 |Key | Default | Description | Since
 |--- | ------- | ----------- | -----
 spark.clickhouse.ignoreUnsupportedTransform|false|ClickHouse supports using complex expressions as sharding keys or partition values, e.g. `cityHash64(col_1, col_2)`, and those can not be supported by Spark now. If `true`, ignore the unsupported expressions, otherwise fail fast w/ an exception. Note, when `spark.clickhouse.write.distributed.convertLocal` is enabled, ignore unsupported sharding keys may corrupt the data.|0.4.0
-spark.clickhouse.read.compression.codec|lz4|The codec used to decompress data for reading. Supported codecs: none, lz4.|0.5.0
+spark.clickhouse.read.compression.codec|none|The codec used to decompress data for reading. Supported codecs: none, lz4.|0.5.0
 spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed table, read local table instead of itself. If `true`, ignore `spark.clickhouse.read.distributed.useClusterNodes`.|0.1.0
 spark.clickhouse.read.fixedStringAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.read.format|json|Serialize format for reading. Supported formats: json, binary|0.6.0
@@ -26,7 +26,7 @@ spark.clickhouse.read.settings|<undefined>|Settings when read from ClickHouse. e
 spark.clickhouse.read.splitByPartitionId|true|If `true`, construct input partition filter by virtual column `_partition_id`, instead of partition value. There are known bugs to assemble SQL predication by partition value. This feature requires ClickHouse Server v21.6+|0.4.0
 spark.clickhouse.useNullableQuerySchema|false|If `true`, mark all the fields of the query schema as nullable when executing `CREATE/REPLACE TABLE ... AS SELECT ...` on creating the table. Note, this configuration requires SPARK-43390(available in Spark 3.5), w/o this patch, it always acts as `true`.|0.8.0
 spark.clickhouse.write.batchSize|10000|The number of records per batch on writing to ClickHouse.|0.1.0
-spark.clickhouse.write.compression.codec|lz4|The codec used to compress data for writing. Supported codecs: none, lz4.|0.3.0
+spark.clickhouse.write.compression.codec|none|The codec used to compress data for writing. Supported codecs: none, lz4.|0.3.0
 spark.clickhouse.write.distributed.convertLocal|false|When writing Distributed table, write local table instead of itself. If `true`, ignore `spark.clickhouse.write.distributed.useClusterNodes`.|0.1.0
 spark.clickhouse.write.distributed.useClusterNodes|true|Write to all nodes of cluster when writing Distributed table.|0.1.0
 spark.clickhouse.write.format|arrow|Serialize format for writing. Supported formats: json, arrow|0.4.0

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -156,14 +156,14 @@ object ClickHouseSQLConf {
       .doc("The codec used to decompress data for reading. Supported codecs: none, lz4.")
       .version("0.5.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val WRITE_COMPRESSION_CODEC: ConfigEntry[String] =
     buildConf("spark.clickhouse.write.compression.codec")
       .doc("The codec used to compress data for writing. Supported codecs: none, lz4.")
       .version("0.3.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val READ_FORMAT: ConfigEntry[String] =
     buildConf("spark.clickhouse.read.format")

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -156,14 +156,14 @@ object ClickHouseSQLConf {
       .doc("The codec used to decompress data for reading. Supported codecs: none, lz4.")
       .version("0.5.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val WRITE_COMPRESSION_CODEC: ConfigEntry[String] =
     buildConf("spark.clickhouse.write.compression.codec")
       .doc("The codec used to compress data for writing. Supported codecs: none, lz4.")
       .version("0.3.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val READ_FORMAT: ConfigEntry[String] =
     buildConf("spark.clickhouse.read.format")

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -156,14 +156,14 @@ object ClickHouseSQLConf {
       .doc("The codec used to decompress data for reading. Supported codecs: none, lz4.")
       .version("0.5.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val WRITE_COMPRESSION_CODEC: ConfigEntry[String] =
     buildConf("spark.clickhouse.write.compression.codec")
       .doc("The codec used to compress data for writing. Supported codecs: none, lz4.")
       .version("0.3.0")
       .stringConf
-      .createWithDefault("lz4")
+      .createWithDefault("none")
 
   val READ_FORMAT: ConfigEntry[String] =
     buildConf("spark.clickhouse.read.format")


### PR DESCRIPTION
Add custom_http_params option to disable HTTP compression for all ClickHouse client connections. This addresses a known issue in the new version of ClickHouse that affects HTTP compression handling.

Changes applied to all Spark versions (3.3, 3.4, 3.5).

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials