### PR TITLE
Add TableProvider implementation with predicate pushdown and column p…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ import org.codehaus.groovy.runtime.GStringImpl
 buildscript {
     repositories {
         maven { url = "https://plugins.gradle.org/m2/" }
+        maven { url = "$mavenCentralMirror" }
     }
     dependencies {
         // Only add SonarQube to classpath if explicitly enabled
@@ -28,6 +29,10 @@ buildscript {
         if (JavaVersion.current() >= JavaVersion.VERSION_11) {
             classpath 'com.gradleup.nmcp:nmcp:0.0.8'
         }
+        // Use newer ASM version that supports Java 21 (class file major version 65)
+        // This allows the shadow plugin to relocate Java 21 compiled classes
+        classpath 'org.ow2.asm:asm:9.6'
+        classpath 'org.ow2.asm:asm-commons:9.6'
     }
 }
 

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
@@ -34,10 +34,19 @@ object JsonProtocol {
 
   @transient lazy val om: ObjectMapper with ClassTagExtensions = {
     val _om = new ObjectMapper() with ClassTagExtensions
-    // Don't use findAndRegisterModules() - it picks up Databricks' shaded Hudi Jackson modules
-    // Instead, manually register only the modules we need
-    _om.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
-    _om.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+
+    // Try to auto-discover and register all Jackson modules
+    // This may fail in Databricks due to shaded Hudi modules with incompatible versions
+    try
+      _om.findAndRegisterModules()
+    catch {
+      case _: Exception =>
+        // Fallback: manually register only the core modules we need
+        // This handles Databricks environments with conflicting shaded Jackson modules
+        _om.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+        _om.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+    }
+
     _om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _om
   }

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
@@ -34,19 +34,7 @@ object JsonProtocol {
 
   @transient lazy val om: ObjectMapper with ClassTagExtensions = {
     val _om = new ObjectMapper() with ClassTagExtensions
-
-    // Try to auto-discover and register all Jackson modules
-    // This may fail in Databricks due to shaded Hudi modules with incompatible versions
-    try
-      _om.findAndRegisterModules()
-    catch {
-      case _: Exception =>
-        // Fallback: manually register only the core modules we need
-        // This handles Databricks environments with conflicting shaded Jackson modules
-        _om.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
-        _om.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
-    }
-
+    _om.findAndRegisterModules()
     _om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _om
   }

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
@@ -34,7 +34,9 @@ object JsonProtocol {
 
   @transient lazy val om: ObjectMapper with ClassTagExtensions = {
     val _om = new ObjectMapper() with ClassTagExtensions
-    _om.findAndRegisterModules()
+    // Don't use findAndRegisterModules() - it picks up Databricks' shaded Hudi Jackson modules
+    // Instead, manually register only the modules we need
+    _om.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
     _om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _om
   }

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/JsonProtocol.scala
@@ -37,6 +37,7 @@ object JsonProtocol {
     // Don't use findAndRegisterModules() - it picks up Databricks' shaded Hudi Jackson modules
     // Instead, manually register only the modules we need
     _om.registerModule(com.fasterxml.jackson.module.scala.DefaultScalaModule)
+    _om.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
     _om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _om
   }

--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/parse/AstVisitor.scala
@@ -89,7 +89,7 @@ class AstVisitor extends ClickHouseSQLBaseVisitor[AnyRef] with Logging {
       .getOrElse(Map.empty)
 
     engine match {
-      case eg: String if "MergeTree" equalsIgnoreCase eg =>
+      case eg: String if ("MergeTree" equalsIgnoreCase eg) || ("SharedMergeTree" equalsIgnoreCase eg) =>
         MergeTreeEngineSpec(
           engine_clause = engineExpr,
           _sorting_key = tupleIfNeeded(orderByOpt.toList),

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -263,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
       )
       assert(
         hasNameFilter,

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -254,6 +254,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
            |WHERE type = 'QueryFinish' 
            |  AND query LIKE '%$dbName%test_filter%'
            |  AND query LIKE '%SELECT%'
+           |  AND query LIKE '%name%'
            |  AND event_time > now() - INTERVAL 10 SECOND
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
@@ -262,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
       )
       assert(
         hasNameFilter,

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -1,0 +1,492 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse.single
+
+import com.clickhouse.spark.base.ClickHouseSingleMixIn
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types._
+
+class ClickHouseSingleTableProviderSuite extends ClickHouseTableProviderSuite with ClickHouseSingleMixIn
+
+/**
+ * Test suite for ClickHouse DataSource V2 TableProvider write capabilities.
+ * Tests format API, write modes, predicate pushdown, and partition overwrite.
+ */
+abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
+
+  import testImplicits._
+
+  private val testSchema = StructType(Seq(
+    StructField("id", IntegerType, nullable = false),
+    StructField("name", StringType, nullable = false),
+    StructField("value", DoubleType, nullable = false),
+    StructField("created", TimestampType, nullable = false)
+  ))
+
+  test("write and read using format API") {
+    withTable("format_api_db", "test_format_api", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      writeData.write
+        .format("clickhouse")
+        .mode(SaveMode.Append)
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .save()
+
+      val readData = spark.read
+        .format("clickhouse")
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .load()
+
+      // Verify schema
+      assert(readData.schema.length == 4)
+      assert(readData.schema.fieldNames.contains("id"))
+      assert(readData.schema.fieldNames.contains("name"))
+
+      // Verify data
+      checkAnswer(
+        readData.orderBy("id"),
+        writeData.orderBy("id")
+      )
+
+      // Verify count
+      assert(readData.count() == 3)
+    }
+  }
+
+  test("append mode adds data without replacing existing") {
+    withTable("append_db", "test_append", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "append_db"), "table" -> "test_append")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val appendData = Seq(
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      appendData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+
+      assert(result.count() == 4)
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+      checkAnswer(
+        result.filter("id = 4"),
+        Row(4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")) :: Nil
+      )
+    }
+  }
+
+  test("schema inference works correctly") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "schema_db"
+    val tableName = "test_schema"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> dbName, "table" -> tableName, "order_by" -> "id")
+
+      // Let the TableProvider create the table from the DataFrame schema
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      // Read back and verify schema inference
+      val inferredDF = spark.read.format("clickhouse").options(options).load()
+
+      assert(inferredDF.schema("id").dataType == IntegerType)
+      assert(inferredDF.schema("name").dataType == StringType)
+      assert(inferredDF.schema("value").dataType == DoubleType)
+      assert(inferredDF.schema("created").dataType == TimestampType)
+
+      // Verify table was actually created
+      assert(inferredDF.count() == 1, "Should have 1 row")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("predicate pushdown filters data server-side") {
+    withTable("filter_db", "test_filter", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")),
+        (5, "Eve", 91.2, timestamp("2024-05-12T16:45:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "filter_db"), "table" -> "test_filter")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val filtered1 = spark.read.format("clickhouse").options(options).load().filter("value > 90")
+      val result1 = filtered1.collect() // Force execution
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "filter_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      val hasFilter = recentQueries.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90")
+      )
+      assert(
+        hasFilter,
+        s"Query should contain WHERE clause with 'value > 90' filter. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(result1.length == 3)
+      checkAnswer(
+        filtered1.select("id").orderBy("id"),
+        Seq(Row(1), Row(3), Row(5))
+      )
+
+      val filtered2 = spark.read.format("clickhouse").options(options).load().filter("name = 'Bob'")
+      val result2 = filtered2.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries2DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
+
+      val hasNameFilter = recentQueries2.exists(query =>
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+      )
+      assert(
+        hasNameFilter,
+        s"Query should contain WHERE clause with 'name = Bob' filter. Recent queries: ${recentQueries2.mkString("; ")}"
+      )
+
+      assert(result2.length == 1)
+      checkAnswer(filtered2, Row(2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")) :: Nil)
+
+      val filtered3 = spark.read.format("clickhouse").options(options).load()
+        .filter("value > 90 AND id < 5")
+      val result3 = filtered3.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries3DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries3 = recentQueries3DF.collect().map(_.getString(0))
+
+      val hasCombinedFilter = recentQueries3.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90") && query.contains("`id` < 5")
+      )
+      assert(
+        hasCombinedFilter,
+        s"Query should contain WHERE clause with 'value > 90 AND id < 5' filters. Recent queries: ${recentQueries3.mkString("; ")}"
+      )
+
+      assert(result3.length == 2)
+      checkAnswer(
+        filtered3.select("name").orderBy("id"),
+        Seq(Row("Alice"), Row("Charlie"))
+      )
+    }
+  }
+
+  test("column pruning reduces data transfer") {
+    withTable("prune_db", "test_prune", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "prune_db"), "table" -> "test_prune")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val selected = spark.read.format("clickhouse").options(options).load().select("id", "name")
+      selected.show()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "prune_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_prune%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      // Check that the query only selects id and name columns, not value or created
+      val hasPrunedColumns = recentQueries.exists(query =>
+        query.contains("SELECT") &&
+          query.contains("`id`") &&
+          query.contains("`name`") &&
+          !query.contains("`value`") &&
+          !query.contains("`created`")
+      )
+      assert(
+        hasPrunedColumns,
+        s"Query should only SELECT id and name columns, not value or created. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(selected.schema.length == 2)
+      assert(selected.schema.fieldNames.contains("id"))
+      assert(selected.schema.fieldNames.contains("name"))
+      assert(!selected.schema.fieldNames.contains("value"))
+      assert(!selected.schema.fieldNames.contains("created"))
+
+      checkAnswer(
+        selected.orderBy("id"),
+        Seq(Row(1, "Alice"), Row(2, "Bob"))
+      )
+    }
+  }
+
+  test("error if exists mode is not supported") {
+    withTable("error_db", "test_error", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "error_db"), "table" -> "test_error")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val newData = Seq(
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val exception = intercept[Exception] {
+        newData.write.format("clickhouse").mode(SaveMode.ErrorIfExists).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("UNSUPPORTED_DATA_SOURCE_SAVE_MODE") ||
+          exception.getMessage.contains("ErrorIfExists"),
+        s"Expected error about unsupported save mode, got: ${exception.getMessage}"
+      )
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 1)
+      checkAnswer(result, Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil)
+    }
+  }
+
+  test("write with null values") {
+    val nullableSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("value", DoubleType, nullable = true)
+    ))
+
+    withTable("null_db", "test_nulls", nullableSchema) {
+      val writeData = Seq(
+        (1, Some("Alice"), Some(95.5)),
+        (2, None, Some(87.3)),
+        (3, Some("Charlie"), None),
+        (4, None, None)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "null_db"), "table" -> "test_nulls")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify null values preserved
+      val row2 = result.filter("id = 2").collect()(0)
+      assert(row2.isNullAt(1), "name should be null")
+      assert(!row2.isNullAt(2), "value should not be null")
+
+      val row3 = result.filter("id = 3").collect()(0)
+      assert(!row3.isNullAt(1), "name should not be null")
+      assert(row3.isNullAt(2), "value should be null")
+
+      val row4 = result.filter("id = 4").collect()(0)
+      assert(row4.isNullAt(1), "name should be null")
+      assert(row4.isNullAt(2), "value should be null")
+    }
+  }
+
+  test("write empty dataframe") {
+    withTable("empty_db", "test_empty", testSchema) {
+      // Create empty DataFrame with proper schema
+      val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
+        .toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "empty_db"), "table" -> "test_empty")
+
+      // Should not fail
+      emptyData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 0, "Table should be empty")
+    }
+  }
+
+  test("order by with nullable columns using allow_nullable_key setting") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "ordered_db"
+    val tableName = "test_ordered_nullable"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(3), Some("C"), 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (Some(1), Some("A"), 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (None, Some("B"), 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (Some(2), None, 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "category", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id, category",
+          "settings.allow_nullable_key" -> "1"
+        )
+
+      // This should succeed because allow_nullable_key is enabled
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify all data is present
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "A", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+
+      // Verify null values are preserved
+      val nullIdRow = result.filter("id IS NULL").collect()
+      assert(nullIdRow.length == 1, "Should have one row with null id")
+      assert(nullIdRow(0).isNullAt(0), "id should be null")
+      assert(nullIdRow(0).getString(1) == "B", "category should be B")
+
+      val nullCategoryRow = result.filter("category IS NULL").collect()
+      assert(nullCategoryRow.length == 1, "Should have one row with null category")
+      assert(nullCategoryRow(0).getInt(0) == 2, "id should be 2")
+      assert(nullCategoryRow(0).isNullAt(1), "category should be null")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("order by without allow_nullable_key setting should fail on nullable columns") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "fail_ordered_db"
+    val tableName = "test_fail_ordered"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(1), "Alice", 95.5),
+        (Some(2), "Bob", 87.3)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id",
+          "settings.allow_nullable_key" -> "0"
+        )
+
+      // This should fail because ORDER BY on nullable column with allow_nullable_key disabled
+      val exception = intercept[Exception] {
+        writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("Sorting key") ||
+          exception.getMessage.contains("nullable") ||
+          exception.getMessage.contains("allow_nullable_key"),
+        s"Expected error about nullable sorting key, got: ${exception.getMessage}"
+      )
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+}

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -171,7 +171,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     db: String,
     tbl: String,
     writeData: Boolean = false
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -210,7 +210,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
           .append
       }
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-3.3/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.3/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.3/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.3/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -104,6 +104,7 @@ case class ClickHouseTable(
       BATCH_READ,
       BATCH_WRITE,
       TRUNCATE,
+      OVERWRITE_BY_FILTER,
       ACCEPT_ANY_SCHEMA // TODO check schema and handle extra columns before writing
     ).asJava
 

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -205,10 +205,14 @@ class ClickHouseTableProvider extends TableProvider
       Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
       Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
     ) ++ (
-      if (optionsMap.contains("ssl")) {
-        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      if (optionsMap.contains(Constants.CATALOG_PROP_TZ)) {
+        Map(Constants.CATALOG_PROP_TZ -> optionsMap(Constants.CATALOG_PROP_TZ))
       } else {
         Map.empty[String, String]
+      }
+    ) ++ (
+      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+        case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )
 

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clickhouse.spark
+
+import com.clickhouse.spark.client.NodeClient
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * TableProvider implementation for ClickHouse, enabling format-based access pattern:
+ * {{{
+ *   spark.read
+ *     .format("clickhouse")
+ *     .option("host", "localhost")
+ *     .option("database", "default")
+ *     .option("table", "my_table")
+ *     .load()
+ * }}}
+ *
+ * This implementation delegates to ClickHouseCatalog for all operations,
+ * ensuring consistent behavior between catalog and format APIs.
+ *
+ * Particularly useful for:
+ * - Ad-hoc queries without catalog configuration
+ * - Databricks Unity Catalog environments
+ * - Simple ETL pipelines
+ * - Multi-cluster access patterns
+ */
+class ClickHouseTableProvider extends TableProvider
+    with DataSourceRegister
+    with ClickHouseHelper {
+
+  override def shortName(): String = "clickhouse"
+
+  /**
+   * Infer schema from ClickHouse table.
+   *
+   * Required options:
+   * - host: ClickHouse host
+   * - database: Database name
+   * - table: Table name
+   *
+   * Optional options:
+   * - protocol: http (default), https, grpc
+   * - http_port: HTTP port (default: 8123)
+   * - user: Username (default: "default")
+   * - password: Password (default: empty)
+   * - ssl: Enable SSL (default: false)
+   * - timezone: Timezone (default: "server")
+   */
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    log.info(s"Inferring schema for ClickHouse with options: ${options.asCaseSensitiveMap()}")
+
+    // Infer schema from table using catalog
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+    try {
+      val table = catalog.loadTable(identifier)
+      log.info(s"Inferred schema from table with ${table.schema.fields.length} fields")
+      table.schema
+    } finally {
+      // Catalog manages its own resources via NodeClient
+    }
+  }
+
+  override def getTable(
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    log.info(s"Getting ClickHouse table with schema: ${schema.simpleString}")
+
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+
+    loadOrCreateTable(catalog, identifier, schema, partitioning, properties)
+  }
+
+  private def loadOrCreateTable(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table =
+    try
+      catalog.loadTable(identifier)
+    catch {
+      case _: NoSuchTableException =>
+        log.info(s"Table $identifier does not exist, creating with provided schema")
+        createTableWithOrderBy(catalog, identifier, schema, partitioning, properties)
+    }
+
+  private def createTableWithOrderBy(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    import scala.collection.JavaConverters._
+    val propsMap = properties.asScala.toMap
+    val updatedProps = ensureOrderByConfiguration(schema, propsMap)
+    catalog.createTable(identifier, schema, partitioning, updatedProps.asJava)
+  }
+
+  private def ensureOrderByConfiguration(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val hasOrderBy = props.contains("order_by") || props.contains("local.order_by")
+
+    if (!hasOrderBy) {
+      addDefaultOrderBy(schema, props)
+    } else {
+      ensureNullableKeySupport(schema, props)
+    }
+  }
+
+  private def addDefaultOrderBy(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    log.info(s"Schema fields: ${schema.fields.map(f => s"${f.name}(nullable=${f.nullable})").mkString(", ")}")
+
+    val orderByColumn = schema.fields
+      .find(!_.nullable)
+      .map(_.name)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "Cannot auto-generate ORDER BY clause: all columns are nullable. " +
+            "ClickHouse Cloud requires non-nullable columns in ORDER BY. " +
+            "Please either: (1) make at least one column non-nullable, or " +
+            "(2) explicitly set 'order_by' option to specify which column(s) to use."
+        )
+      }
+
+    log.info(s"Auto-generated ORDER BY clause: $orderByColumn")
+    props + ("order_by" -> orderByColumn)
+  }
+
+  private def ensureNullableKeySupport(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val orderByColumns = props
+      .getOrElse("order_by", props.getOrElse("local.order_by", ""))
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    val hasNullableOrderByColumn = orderByColumns.exists { colName =>
+      schema.fields.find(_.name.equalsIgnoreCase(colName)).exists(_.nullable)
+    }
+
+    if (hasNullableOrderByColumn && !props.contains("settings.allow_nullable_key")) {
+      log.info("ORDER BY contains nullable columns, adding settings.allow_nullable_key=1")
+      props + ("settings.allow_nullable_key" -> "1")
+    } else {
+      props
+    }
+  }
+
+  override def supportsExternalMetadata(): Boolean = true
+
+  private def extractIdentifier(options: CaseInsensitiveStringMap): Identifier = {
+    val database = options.getOrDefault("database", "default")
+    val table = options.get("table")
+
+    if (table == null || table.isEmpty) {
+      throw new IllegalArgumentException(
+        "Required option 'table' is missing. Please provide it via .option('table', 'value')"
+      )
+    }
+
+    Identifier.of(Array(database), table)
+  }
+
+  private def createCatalog(options: CaseInsensitiveStringMap): ClickHouseCatalog = {
+    import scala.collection.JavaConverters._
+
+    val catalog = new ClickHouseCatalog()
+
+    val optionsMap = options.asCaseSensitiveMap().asScala.toMap
+    val normalizedOptions = optionsMap ++ Map(
+      Constants.CATALOG_PROP_HOST -> optionsMap.getOrElse("host", ""),
+      Constants.CATALOG_PROP_DATABASE -> optionsMap.getOrElse("database", "default"),
+      Constants.CATALOG_PROP_HTTP_PORT -> optionsMap.getOrElse("http_port", "8123"),
+      Constants.CATALOG_PROP_PROTOCOL -> optionsMap.getOrElse("protocol", "http"),
+      Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
+      Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
+    ) ++ (
+      if (optionsMap.contains("ssl")) {
+        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      } else {
+        Map.empty[String, String]
+      }
+    )
+
+    catalog.initialize("_temp_catalog", new CaseInsensitiveStringMap(normalizedOptions.asJava))
+
+    catalog
+  }
+}

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -211,7 +211,7 @@ class ClickHouseTableProvider extends TableProvider
         Map.empty[String, String]
       }
     ) ++ (
-      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+      optionsMap.filter { case (key, _) => key == "ssl" || key == "ssl_mode" }.map {
         case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -49,14 +49,6 @@ class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
       case _: AlwaysTrue => true
       case _ => false
     }
-
-    if (hasPartitionFilters) {
-      log.warn(
-        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
-      )
-    } else {
-      log.info("Full table overwrite (no partition filters)")
-    }
     this
   }
 }
@@ -112,11 +104,9 @@ class ClickHouseBatchWrite(
       writeJob.tableEngineSpec match {
         case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
           val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
         case _ =>
           val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
       }
     }

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -14,29 +14,61 @@
 
 package com.clickhouse.spark.write
 
+import com.clickhouse.spark.{BytesWrittenMetric, RecordsWrittenMetric, SerializeTimeMetric, WriteTimeMetric}
+import com.clickhouse.spark.exception.CHClientException
+import com.clickhouse.spark.write.format.{ClickHouseArrowStreamWriter, ClickHouseJsonEachRowWriter}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
 import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
 import org.apache.spark.sql.connector.expressions.SortOrder
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.write._
+import org.apache.spark.sql.sources.Filter
 import com.clickhouse.spark._
-import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.write.format.{ClickHouseArrowStreamWriter, ClickHouseJsonEachRowWriter}
+import com.clickhouse.spark.spec.DistributedEngineSpec
+import org.apache.spark.sql.sources.AlwaysTrue
 
-class ClickHouseWriteBuilder(writeJob: WriteJobDescription) extends WriteBuilder {
+class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
+    extends WriteBuilder
+    with SupportsOverwrite
+    with Logging {
 
-  override def build(): Write = new ClickHouseWrite(writeJob)
+  private var isOverwrite: Boolean = false
+  private var overwriteFilters: Array[Filter] = Array.empty
+
+  override def build(): Write = new ClickHouseWrite(writeJob, isOverwrite, overwriteFilters)
+
+  override def overwrite(filters: Array[Filter]): WriteBuilder = {
+    log.info(s"Overwrite mode for table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)}")
+    isOverwrite = true
+    overwriteFilters = filters
+
+    // Check if we have actual partition filters (not AlwaysTrue or empty)
+    val hasPartitionFilters = filters.nonEmpty && !filters.forall {
+      case _: AlwaysTrue => true
+      case _ => false
+    }
+
+    if (hasPartitionFilters) {
+      log.warn(
+        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
+      )
+    } else {
+      log.info("Full table overwrite (no partition filters)")
+    }
+    this
+  }
 }
 
 class ClickHouseWrite(
-  writeJob: WriteJobDescription
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false,
+  overwriteFilters: Array[Filter] = Array.empty
 ) extends Write
     with RequiresDistributionAndOrdering
-    with SQLConfHelper {
-
-  // for SPARK-37523
-  def distributionStrictlyRequired: Boolean = writeJob.writeOptions.repartitionStrictly
+    with SQLConfHelper
+    with Logging {
 
   override def description: String =
     s"ClickHouseWrite(database=${writeJob.targetDatabase(false)}, table=${writeJob.targetTable(false)})})"
@@ -47,7 +79,7 @@ class ClickHouseWrite(
 
   override def requiredOrdering(): Array[SortOrder] = writeJob.sparkSortOrders
 
-  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob)
+  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob, isOverwrite)
 
   override def supportedCustomMetrics(): Array[CustomMetric] = Array(
     RecordsWrittenMetric(),
@@ -58,10 +90,37 @@ class ClickHouseWrite(
 }
 
 class ClickHouseBatchWrite(
-  writeJob: WriteJobDescription
-) extends BatchWrite with DataWriterFactory {
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false
+) extends BatchWrite with DataWriterFactory with Logging {
 
-  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = this
+  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+    // Truncate table before writing if overwrite mode is enabled
+    if (isOverwrite) {
+      truncateTable()
+    }
+    this
+  }
+
+  private def truncateTable(): Unit = {
+    import com.clickhouse.spark.client.NodeClient
+    import com.clickhouse.spark.Utils
+
+    log.info(s"Truncating table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)} for overwrite mode")
+
+    Utils.tryWithResource(NodeClient(writeJob.node)) { implicit nodeClient =>
+      writeJob.tableEngineSpec match {
+        case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+        case _ =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+      }
+    }
+  }
 
   override def commit(messages: Array[WriterCommitMessage]): Unit = {}
 

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
@@ -60,15 +60,32 @@ case class WriteJobDescription(
     case _ => None
   }
 
-  def sparkSplits: Array[Transform] =
-    if (writeOptions.repartitionByPartition) {
-      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, partitionKey)
+  // For SharedMergeTree, filter out unsupported partition expressions while keeping supported ones.
+  private lazy val isSharedMergeTree: Boolean =
+    tableEngineSpec.engine_clause.toLowerCase.contains("sharedmergetree")
+
+  private def filterSupportedPartitionExprs(exprs: Option[List[Expr]]): Option[List[Expr]] = {
+    if (!isSharedMergeTree) return exprs
+    exprs.map(_.flatMap { expr =>
+      scala.util.Try(ExprUtils.toSparkTransform(expr)).toOption.map(_ => expr)
+    })
+  }
+
+  def sparkSplits: Array[Transform] = {
+    val _partitionKey = if (writeOptions.repartitionByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
     } else {
-      ExprUtils.toSparkSplits(shardingKeyIgnoreRand, None)
+      None
     }
+    ExprUtils.toSparkSplits(shardingKeyIgnoreRand, _partitionKey)
+  }
 
   def sparkSortOrders: Array[SortOrder] = {
-    val _partitionKey = if (writeOptions.localSortByPartition) partitionKey else None
+    val _partitionKey = if (writeOptions.localSortByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
+    } else {
+      None
+    }
     val _sortingKey = if (writeOptions.localSortByKey) sortingKey else None
     ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, _partitionKey, _sortingKey)
   }

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -263,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
       )
       assert(
         hasNameFilter,

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -254,6 +254,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
            |WHERE type = 'QueryFinish' 
            |  AND query LIKE '%$dbName%test_filter%'
            |  AND query LIKE '%SELECT%'
+           |  AND query LIKE '%name%'
            |  AND event_time > now() - INTERVAL 10 SECOND
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
@@ -262,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
       )
       assert(
         hasNameFilter,

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -1,0 +1,492 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse.single
+
+import com.clickhouse.spark.base.ClickHouseSingleMixIn
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types._
+
+class ClickHouseSingleTableProviderSuite extends ClickHouseTableProviderSuite with ClickHouseSingleMixIn
+
+/**
+ * Test suite for ClickHouse DataSource V2 TableProvider write capabilities.
+ * Tests format API, write modes, predicate pushdown, and partition overwrite.
+ */
+abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
+
+  import testImplicits._
+
+  private val testSchema = StructType(Seq(
+    StructField("id", IntegerType, nullable = false),
+    StructField("name", StringType, nullable = false),
+    StructField("value", DoubleType, nullable = false),
+    StructField("created", TimestampType, nullable = false)
+  ))
+
+  test("write and read using format API") {
+    withTable("format_api_db", "test_format_api", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      writeData.write
+        .format("clickhouse")
+        .mode(SaveMode.Append)
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .save()
+
+      val readData = spark.read
+        .format("clickhouse")
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .load()
+
+      // Verify schema
+      assert(readData.schema.length == 4)
+      assert(readData.schema.fieldNames.contains("id"))
+      assert(readData.schema.fieldNames.contains("name"))
+
+      // Verify data
+      checkAnswer(
+        readData.orderBy("id"),
+        writeData.orderBy("id")
+      )
+
+      // Verify count
+      assert(readData.count() == 3)
+    }
+  }
+
+  test("append mode adds data without replacing existing") {
+    withTable("append_db", "test_append", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "append_db"), "table" -> "test_append")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val appendData = Seq(
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      appendData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+
+      assert(result.count() == 4)
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+      checkAnswer(
+        result.filter("id = 4"),
+        Row(4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")) :: Nil
+      )
+    }
+  }
+
+  test("schema inference works correctly") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "schema_db"
+    val tableName = "test_schema"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> dbName, "table" -> tableName, "order_by" -> "id")
+
+      // Let the TableProvider create the table from the DataFrame schema
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      // Read back and verify schema inference
+      val inferredDF = spark.read.format("clickhouse").options(options).load()
+
+      assert(inferredDF.schema("id").dataType == IntegerType)
+      assert(inferredDF.schema("name").dataType == StringType)
+      assert(inferredDF.schema("value").dataType == DoubleType)
+      assert(inferredDF.schema("created").dataType == TimestampType)
+
+      // Verify table was actually created
+      assert(inferredDF.count() == 1, "Should have 1 row")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("predicate pushdown filters data server-side") {
+    withTable("filter_db", "test_filter", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")),
+        (5, "Eve", 91.2, timestamp("2024-05-12T16:45:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "filter_db"), "table" -> "test_filter")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val filtered1 = spark.read.format("clickhouse").options(options).load().filter("value > 90")
+      val result1 = filtered1.collect() // Force execution
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "filter_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      val hasFilter = recentQueries.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90")
+      )
+      assert(
+        hasFilter,
+        s"Query should contain WHERE clause with 'value > 90' filter. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(result1.length == 3)
+      checkAnswer(
+        filtered1.select("id").orderBy("id"),
+        Seq(Row(1), Row(3), Row(5))
+      )
+
+      val filtered2 = spark.read.format("clickhouse").options(options).load().filter("name = 'Bob'")
+      val result2 = filtered2.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries2DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
+
+      val hasNameFilter = recentQueries2.exists(query =>
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+      )
+      assert(
+        hasNameFilter,
+        s"Query should contain WHERE clause with 'name = Bob' filter. Recent queries: ${recentQueries2.mkString("; ")}"
+      )
+
+      assert(result2.length == 1)
+      checkAnswer(filtered2, Row(2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")) :: Nil)
+
+      val filtered3 = spark.read.format("clickhouse").options(options).load()
+        .filter("value > 90 AND id < 5")
+      val result3 = filtered3.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries3DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries3 = recentQueries3DF.collect().map(_.getString(0))
+
+      val hasCombinedFilter = recentQueries3.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90") && query.contains("`id` < 5")
+      )
+      assert(
+        hasCombinedFilter,
+        s"Query should contain WHERE clause with 'value > 90 AND id < 5' filters. Recent queries: ${recentQueries3.mkString("; ")}"
+      )
+
+      assert(result3.length == 2)
+      checkAnswer(
+        filtered3.select("name").orderBy("id"),
+        Seq(Row("Alice"), Row("Charlie"))
+      )
+    }
+  }
+
+  test("column pruning reduces data transfer") {
+    withTable("prune_db", "test_prune", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "prune_db"), "table" -> "test_prune")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val selected = spark.read.format("clickhouse").options(options).load().select("id", "name")
+      selected.show()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "prune_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_prune%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      // Check that the query only selects id and name columns, not value or created
+      val hasPrunedColumns = recentQueries.exists(query =>
+        query.contains("SELECT") &&
+          query.contains("`id`") &&
+          query.contains("`name`") &&
+          !query.contains("`value`") &&
+          !query.contains("`created`")
+      )
+      assert(
+        hasPrunedColumns,
+        s"Query should only SELECT id and name columns, not value or created. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(selected.schema.length == 2)
+      assert(selected.schema.fieldNames.contains("id"))
+      assert(selected.schema.fieldNames.contains("name"))
+      assert(!selected.schema.fieldNames.contains("value"))
+      assert(!selected.schema.fieldNames.contains("created"))
+
+      checkAnswer(
+        selected.orderBy("id"),
+        Seq(Row(1, "Alice"), Row(2, "Bob"))
+      )
+    }
+  }
+
+  test("error if exists mode is not supported") {
+    withTable("error_db", "test_error", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "error_db"), "table" -> "test_error")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val newData = Seq(
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val exception = intercept[Exception] {
+        newData.write.format("clickhouse").mode(SaveMode.ErrorIfExists).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("UNSUPPORTED_DATA_SOURCE_SAVE_MODE") ||
+          exception.getMessage.contains("ErrorIfExists"),
+        s"Expected error about unsupported save mode, got: ${exception.getMessage}"
+      )
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 1)
+      checkAnswer(result, Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil)
+    }
+  }
+
+  test("write with null values") {
+    val nullableSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("value", DoubleType, nullable = true)
+    ))
+
+    withTable("null_db", "test_nulls", nullableSchema) {
+      val writeData = Seq(
+        (1, Some("Alice"), Some(95.5)),
+        (2, None, Some(87.3)),
+        (3, Some("Charlie"), None),
+        (4, None, None)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "null_db"), "table" -> "test_nulls")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify null values preserved
+      val row2 = result.filter("id = 2").collect()(0)
+      assert(row2.isNullAt(1), "name should be null")
+      assert(!row2.isNullAt(2), "value should not be null")
+
+      val row3 = result.filter("id = 3").collect()(0)
+      assert(!row3.isNullAt(1), "name should not be null")
+      assert(row3.isNullAt(2), "value should be null")
+
+      val row4 = result.filter("id = 4").collect()(0)
+      assert(row4.isNullAt(1), "name should be null")
+      assert(row4.isNullAt(2), "value should be null")
+    }
+  }
+
+  test("write empty dataframe") {
+    withTable("empty_db", "test_empty", testSchema) {
+      // Create empty DataFrame with proper schema
+      val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
+        .toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "empty_db"), "table" -> "test_empty")
+
+      // Should not fail
+      emptyData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 0, "Table should be empty")
+    }
+  }
+
+  test("order by with nullable columns using allow_nullable_key setting") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "ordered_db"
+    val tableName = "test_ordered_nullable"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(3), Some("C"), 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (Some(1), Some("A"), 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (None, Some("B"), 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (Some(2), None, 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "category", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id, category",
+          "settings.allow_nullable_key" -> "1"
+        )
+
+      // This should succeed because allow_nullable_key is enabled
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify all data is present
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "A", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+
+      // Verify null values are preserved
+      val nullIdRow = result.filter("id IS NULL").collect()
+      assert(nullIdRow.length == 1, "Should have one row with null id")
+      assert(nullIdRow(0).isNullAt(0), "id should be null")
+      assert(nullIdRow(0).getString(1) == "B", "category should be B")
+
+      val nullCategoryRow = result.filter("category IS NULL").collect()
+      assert(nullCategoryRow.length == 1, "Should have one row with null category")
+      assert(nullCategoryRow(0).getInt(0) == 2, "id should be 2")
+      assert(nullCategoryRow(0).isNullAt(1), "category should be null")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("order by without allow_nullable_key setting should fail on nullable columns") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "fail_ordered_db"
+    val tableName = "test_fail_ordered"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(1), "Alice", 95.5),
+        (Some(2), "Bob", 87.3)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id",
+          "settings.allow_nullable_key" -> "0"
+        )
+
+      // This should fail because ORDER BY on nullable column with allow_nullable_key disabled
+      val exception = intercept[Exception] {
+        writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("Sorting key") ||
+          exception.getMessage.contains("nullable") ||
+          exception.getMessage.contains("allow_nullable_key"),
+        s"Expected error about nullable sorting key, got: ${exception.getMessage}"
+      )
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+}

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -170,7 +170,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     db: String,
     tbl: String,
     writeData: Boolean = false
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -208,7 +208,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
           .append
       }
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-3.4/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.4/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.4/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.4/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -105,6 +105,7 @@ case class ClickHouseTable(
       BATCH_READ,
       BATCH_WRITE,
       TRUNCATE,
+      OVERWRITE_BY_FILTER,
       ACCEPT_ANY_SCHEMA // TODO check schema and handle extra columns before writing
     ).asJava
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -205,10 +205,14 @@ class ClickHouseTableProvider extends TableProvider
       Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
       Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
     ) ++ (
-      if (optionsMap.contains("ssl")) {
-        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      if (optionsMap.contains(Constants.CATALOG_PROP_TZ)) {
+        Map(Constants.CATALOG_PROP_TZ -> optionsMap(Constants.CATALOG_PROP_TZ))
       } else {
         Map.empty[String, String]
+      }
+    ) ++ (
+      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+        case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clickhouse.spark
+
+import com.clickhouse.spark.client.NodeClient
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * TableProvider implementation for ClickHouse, enabling format-based access pattern:
+ * {{{
+ *   spark.read
+ *     .format("clickhouse")
+ *     .option("host", "localhost")
+ *     .option("database", "default")
+ *     .option("table", "my_table")
+ *     .load()
+ * }}}
+ *
+ * This implementation delegates to ClickHouseCatalog for all operations,
+ * ensuring consistent behavior between catalog and format APIs.
+ *
+ * Particularly useful for:
+ * - Ad-hoc queries without catalog configuration
+ * - Databricks Unity Catalog environments
+ * - Simple ETL pipelines
+ * - Multi-cluster access patterns
+ */
+class ClickHouseTableProvider extends TableProvider
+    with DataSourceRegister
+    with ClickHouseHelper {
+
+  override def shortName(): String = "clickhouse"
+
+  /**
+   * Infer schema from ClickHouse table.
+   *
+   * Required options:
+   * - host: ClickHouse host
+   * - database: Database name
+   * - table: Table name
+   *
+   * Optional options:
+   * - protocol: http (default), https, grpc
+   * - http_port: HTTP port (default: 8123)
+   * - user: Username (default: "default")
+   * - password: Password (default: empty)
+   * - ssl: Enable SSL (default: false)
+   * - timezone: Timezone (default: "server")
+   */
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    log.info(s"Inferring schema for ClickHouse with options: ${options.asCaseSensitiveMap()}")
+
+    // Infer schema from table using catalog
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+    try {
+      val table = catalog.loadTable(identifier)
+      log.info(s"Inferred schema from table with ${table.schema.fields.length} fields")
+      table.schema
+    } finally {
+      // Catalog manages its own resources via NodeClient
+    }
+  }
+
+  override def getTable(
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    log.info(s"Getting ClickHouse table with schema: ${schema.simpleString}")
+
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+
+    loadOrCreateTable(catalog, identifier, schema, partitioning, properties)
+  }
+
+  private def loadOrCreateTable(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table =
+    try
+      catalog.loadTable(identifier)
+    catch {
+      case _: NoSuchTableException =>
+        log.info(s"Table $identifier does not exist, creating with provided schema")
+        createTableWithOrderBy(catalog, identifier, schema, partitioning, properties)
+    }
+
+  private def createTableWithOrderBy(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    import scala.collection.JavaConverters._
+    val propsMap = properties.asScala.toMap
+    val updatedProps = ensureOrderByConfiguration(schema, propsMap)
+    catalog.createTable(identifier, schema, partitioning, updatedProps.asJava)
+  }
+
+  private def ensureOrderByConfiguration(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val hasOrderBy = props.contains("order_by") || props.contains("local.order_by")
+
+    if (!hasOrderBy) {
+      addDefaultOrderBy(schema, props)
+    } else {
+      ensureNullableKeySupport(schema, props)
+    }
+  }
+
+  private def addDefaultOrderBy(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    log.info(s"Schema fields: ${schema.fields.map(f => s"${f.name}(nullable=${f.nullable})").mkString(", ")}")
+
+    val orderByColumn = schema.fields
+      .find(!_.nullable)
+      .map(_.name)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "Cannot auto-generate ORDER BY clause: all columns are nullable. " +
+            "ClickHouse Cloud requires non-nullable columns in ORDER BY. " +
+            "Please either: (1) make at least one column non-nullable, or " +
+            "(2) explicitly set 'order_by' option to specify which column(s) to use."
+        )
+      }
+
+    log.info(s"Auto-generated ORDER BY clause: $orderByColumn")
+    props + ("order_by" -> orderByColumn)
+  }
+
+  private def ensureNullableKeySupport(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val orderByColumns = props
+      .getOrElse("order_by", props.getOrElse("local.order_by", ""))
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    val hasNullableOrderByColumn = orderByColumns.exists { colName =>
+      schema.fields.find(_.name.equalsIgnoreCase(colName)).exists(_.nullable)
+    }
+
+    if (hasNullableOrderByColumn && !props.contains("settings.allow_nullable_key")) {
+      log.info("ORDER BY contains nullable columns, adding settings.allow_nullable_key=1")
+      props + ("settings.allow_nullable_key" -> "1")
+    } else {
+      props
+    }
+  }
+
+  override def supportsExternalMetadata(): Boolean = true
+
+  private def extractIdentifier(options: CaseInsensitiveStringMap): Identifier = {
+    val database = options.getOrDefault("database", "default")
+    val table = options.get("table")
+
+    if (table == null || table.isEmpty) {
+      throw new IllegalArgumentException(
+        "Required option 'table' is missing. Please provide it via .option('table', 'value')"
+      )
+    }
+
+    Identifier.of(Array(database), table)
+  }
+
+  private def createCatalog(options: CaseInsensitiveStringMap): ClickHouseCatalog = {
+    import scala.collection.JavaConverters._
+
+    val catalog = new ClickHouseCatalog()
+
+    val optionsMap = options.asCaseSensitiveMap().asScala.toMap
+    val normalizedOptions = optionsMap ++ Map(
+      Constants.CATALOG_PROP_HOST -> optionsMap.getOrElse("host", ""),
+      Constants.CATALOG_PROP_DATABASE -> optionsMap.getOrElse("database", "default"),
+      Constants.CATALOG_PROP_HTTP_PORT -> optionsMap.getOrElse("http_port", "8123"),
+      Constants.CATALOG_PROP_PROTOCOL -> optionsMap.getOrElse("protocol", "http"),
+      Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
+      Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
+    ) ++ (
+      if (optionsMap.contains("ssl")) {
+        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      } else {
+        Map.empty[String, String]
+      }
+    )
+
+    catalog.initialize("_temp_catalog", new CaseInsensitiveStringMap(normalizedOptions.asJava))
+
+    catalog
+  }
+}

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -211,7 +211,7 @@ class ClickHouseTableProvider extends TableProvider
         Map.empty[String, String]
       }
     ) ++ (
-      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+      optionsMap.filter { case (key, _) => key == "ssl" || key == "ssl_mode" }.map {
         case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -62,6 +62,8 @@ class ClickHouseWrite(
     with SQLConfHelper
     with Logging {
 
+  override def distributionStrictlyRequired: Boolean = writeJob.writeOptions.repartitionStrictly
+
   override def description: String =
     s"ClickHouseWrite(database=${writeJob.targetDatabase(false)}, table=${writeJob.targetTable(false)})})"
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -49,14 +49,6 @@ class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
       case _: AlwaysTrue => true
       case _ => false
     }
-
-    if (hasPartitionFilters) {
-      log.warn(
-        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
-      )
-    } else {
-      log.info("Full table overwrite (no partition filters)")
-    }
     this
   }
 }
@@ -112,11 +104,9 @@ class ClickHouseBatchWrite(
       writeJob.tableEngineSpec match {
         case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
           val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
         case _ =>
           val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
       }
     }

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -14,28 +14,61 @@
 
 package com.clickhouse.spark.write
 
+import com.clickhouse.spark.{BytesWrittenMetric, RecordsWrittenMetric, SerializeTimeMetric, WriteTimeMetric}
+import com.clickhouse.spark.exception.CHClientException
+import com.clickhouse.spark.write.format.{ClickHouseArrowStreamWriter, ClickHouseJsonEachRowWriter}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
 import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
 import org.apache.spark.sql.connector.expressions.SortOrder
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.write._
+import org.apache.spark.sql.sources.Filter
 import com.clickhouse.spark._
-import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.write.format.{ClickHouseArrowStreamWriter, ClickHouseJsonEachRowWriter}
+import com.clickhouse.spark.spec.DistributedEngineSpec
+import org.apache.spark.sql.sources.AlwaysTrue
 
-class ClickHouseWriteBuilder(writeJob: WriteJobDescription) extends WriteBuilder {
+class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
+    extends WriteBuilder
+    with SupportsOverwrite
+    with Logging {
 
-  override def build(): Write = new ClickHouseWrite(writeJob)
+  private var isOverwrite: Boolean = false
+  private var overwriteFilters: Array[Filter] = Array.empty
+
+  override def build(): Write = new ClickHouseWrite(writeJob, isOverwrite, overwriteFilters)
+
+  override def overwrite(filters: Array[Filter]): WriteBuilder = {
+    log.info(s"Overwrite mode for table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)}")
+    isOverwrite = true
+    overwriteFilters = filters
+
+    // Check if we have actual partition filters (not AlwaysTrue or empty)
+    val hasPartitionFilters = filters.nonEmpty && !filters.forall {
+      case _: AlwaysTrue => true
+      case _ => false
+    }
+
+    if (hasPartitionFilters) {
+      log.warn(
+        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
+      )
+    } else {
+      log.info("Full table overwrite (no partition filters)")
+    }
+    this
+  }
 }
 
 class ClickHouseWrite(
-  writeJob: WriteJobDescription
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false,
+  overwriteFilters: Array[Filter] = Array.empty
 ) extends Write
     with RequiresDistributionAndOrdering
-    with SQLConfHelper {
-
-  override def distributionStrictlyRequired: Boolean = writeJob.writeOptions.repartitionStrictly
+    with SQLConfHelper
+    with Logging {
 
   override def description: String =
     s"ClickHouseWrite(database=${writeJob.targetDatabase(false)}, table=${writeJob.targetTable(false)})})"
@@ -46,7 +79,7 @@ class ClickHouseWrite(
 
   override def requiredOrdering(): Array[SortOrder] = writeJob.sparkSortOrders
 
-  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob)
+  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob, isOverwrite)
 
   override def supportedCustomMetrics(): Array[CustomMetric] = Array(
     RecordsWrittenMetric(),
@@ -57,10 +90,37 @@ class ClickHouseWrite(
 }
 
 class ClickHouseBatchWrite(
-  writeJob: WriteJobDescription
-) extends BatchWrite with DataWriterFactory {
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false
+) extends BatchWrite with DataWriterFactory with Logging {
 
-  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = this
+  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+    // Truncate table before writing if overwrite mode is enabled
+    if (isOverwrite) {
+      truncateTable()
+    }
+    this
+  }
+
+  private def truncateTable(): Unit = {
+    import com.clickhouse.spark.client.NodeClient
+    import com.clickhouse.spark.Utils
+
+    log.info(s"Truncating table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)} for overwrite mode")
+
+    Utils.tryWithResource(NodeClient(writeJob.node)) { implicit nodeClient =>
+      writeJob.tableEngineSpec match {
+        case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+        case _ =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+      }
+    }
+  }
 
   override def commit(messages: Array[WriterCommitMessage]): Unit = {}
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -263,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
       )
       assert(
         hasNameFilter,

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -254,6 +254,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
            |WHERE type = 'QueryFinish' 
            |  AND query LIKE '%$dbName%test_filter%'
            |  AND query LIKE '%SELECT%'
+           |  AND query LIKE '%name%'
            |  AND event_time > now() - INTERVAL 10 SECOND
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
@@ -262,7 +263,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
 
       val hasNameFilter = recentQueries2.exists(query =>
-        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+        query.contains("WHERE") && (query.contains("`name` = 'Bob'") || query.contains("`name`='Bob'"))
       )
       assert(
         hasNameFilter,

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -1,0 +1,492 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse.single
+
+import com.clickhouse.spark.base.ClickHouseSingleMixIn
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types._
+
+class ClickHouseSingleTableProviderSuite extends ClickHouseTableProviderSuite with ClickHouseSingleMixIn
+
+/**
+ * Test suite for ClickHouse DataSource V2 TableProvider write capabilities.
+ * Tests format API, write modes, predicate pushdown, and partition overwrite.
+ */
+abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
+
+  import testImplicits._
+
+  private val testSchema = StructType(Seq(
+    StructField("id", IntegerType, nullable = false),
+    StructField("name", StringType, nullable = false),
+    StructField("value", DoubleType, nullable = false),
+    StructField("created", TimestampType, nullable = false)
+  ))
+
+  test("write and read using format API") {
+    withTable("format_api_db", "test_format_api", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      writeData.write
+        .format("clickhouse")
+        .mode(SaveMode.Append)
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .save()
+
+      val readData = spark.read
+        .format("clickhouse")
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .load()
+
+      // Verify schema
+      assert(readData.schema.length == 4)
+      assert(readData.schema.fieldNames.contains("id"))
+      assert(readData.schema.fieldNames.contains("name"))
+
+      // Verify data
+      checkAnswer(
+        readData.orderBy("id"),
+        writeData.orderBy("id")
+      )
+
+      // Verify count
+      assert(readData.count() == 3)
+    }
+  }
+
+  test("append mode adds data without replacing existing") {
+    withTable("append_db", "test_append", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "append_db"), "table" -> "test_append")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val appendData = Seq(
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      appendData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+
+      assert(result.count() == 4)
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+      checkAnswer(
+        result.filter("id = 4"),
+        Row(4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")) :: Nil
+      )
+    }
+  }
+
+  test("schema inference works correctly") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "schema_db"
+    val tableName = "test_schema"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> dbName, "table" -> tableName, "order_by" -> "id")
+
+      // Let the TableProvider create the table from the DataFrame schema
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      // Read back and verify schema inference
+      val inferredDF = spark.read.format("clickhouse").options(options).load()
+
+      assert(inferredDF.schema("id").dataType == IntegerType)
+      assert(inferredDF.schema("name").dataType == StringType)
+      assert(inferredDF.schema("value").dataType == DoubleType)
+      assert(inferredDF.schema("created").dataType == TimestampType)
+
+      // Verify table was actually created
+      assert(inferredDF.count() == 1, "Should have 1 row")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("predicate pushdown filters data server-side") {
+    withTable("filter_db", "test_filter", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")),
+        (5, "Eve", 91.2, timestamp("2024-05-12T16:45:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "filter_db"), "table" -> "test_filter")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val filtered1 = spark.read.format("clickhouse").options(options).load().filter("value > 90")
+      val result1 = filtered1.collect() // Force execution
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "filter_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      val hasFilter = recentQueries.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90")
+      )
+      assert(
+        hasFilter,
+        s"Query should contain WHERE clause with 'value > 90' filter. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(result1.length == 3)
+      checkAnswer(
+        filtered1.select("id").orderBy("id"),
+        Seq(Row(1), Row(3), Row(5))
+      )
+
+      val filtered2 = spark.read.format("clickhouse").options(options).load().filter("name = 'Bob'")
+      val result2 = filtered2.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries2DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
+
+      val hasNameFilter = recentQueries2.exists(query =>
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+      )
+      assert(
+        hasNameFilter,
+        s"Query should contain WHERE clause with 'name = Bob' filter. Recent queries: ${recentQueries2.mkString("; ")}"
+      )
+
+      assert(result2.length == 1)
+      checkAnswer(filtered2, Row(2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")) :: Nil)
+
+      val filtered3 = spark.read.format("clickhouse").options(options).load()
+        .filter("value > 90 AND id < 5")
+      val result3 = filtered3.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries3DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries3 = recentQueries3DF.collect().map(_.getString(0))
+
+      val hasCombinedFilter = recentQueries3.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90") && query.contains("`id` < 5")
+      )
+      assert(
+        hasCombinedFilter,
+        s"Query should contain WHERE clause with 'value > 90 AND id < 5' filters. Recent queries: ${recentQueries3.mkString("; ")}"
+      )
+
+      assert(result3.length == 2)
+      checkAnswer(
+        filtered3.select("name").orderBy("id"),
+        Seq(Row("Alice"), Row("Charlie"))
+      )
+    }
+  }
+
+  test("column pruning reduces data transfer") {
+    withTable("prune_db", "test_prune", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "prune_db"), "table" -> "test_prune")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val selected = spark.read.format("clickhouse").options(options).load().select("id", "name")
+      selected.show()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "prune_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_prune%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      // Check that the query only selects id and name columns, not value or created
+      val hasPrunedColumns = recentQueries.exists(query =>
+        query.contains("SELECT") &&
+          query.contains("`id`") &&
+          query.contains("`name`") &&
+          !query.contains("`value`") &&
+          !query.contains("`created`")
+      )
+      assert(
+        hasPrunedColumns,
+        s"Query should only SELECT id and name columns, not value or created. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(selected.schema.length == 2)
+      assert(selected.schema.fieldNames.contains("id"))
+      assert(selected.schema.fieldNames.contains("name"))
+      assert(!selected.schema.fieldNames.contains("value"))
+      assert(!selected.schema.fieldNames.contains("created"))
+
+      checkAnswer(
+        selected.orderBy("id"),
+        Seq(Row(1, "Alice"), Row(2, "Bob"))
+      )
+    }
+  }
+
+  test("error if exists mode is not supported") {
+    withTable("error_db", "test_error", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "error_db"), "table" -> "test_error")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val newData = Seq(
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val exception = intercept[Exception] {
+        newData.write.format("clickhouse").mode(SaveMode.ErrorIfExists).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("UNSUPPORTED_DATA_SOURCE_SAVE_MODE") ||
+          exception.getMessage.contains("ErrorIfExists"),
+        s"Expected error about unsupported save mode, got: ${exception.getMessage}"
+      )
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 1)
+      checkAnswer(result, Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil)
+    }
+  }
+
+  test("write with null values") {
+    val nullableSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("value", DoubleType, nullable = true)
+    ))
+
+    withTable("null_db", "test_nulls", nullableSchema) {
+      val writeData = Seq(
+        (1, Some("Alice"), Some(95.5)),
+        (2, None, Some(87.3)),
+        (3, Some("Charlie"), None),
+        (4, None, None)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "null_db"), "table" -> "test_nulls")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify null values preserved
+      val row2 = result.filter("id = 2").collect()(0)
+      assert(row2.isNullAt(1), "name should be null")
+      assert(!row2.isNullAt(2), "value should not be null")
+
+      val row3 = result.filter("id = 3").collect()(0)
+      assert(!row3.isNullAt(1), "name should not be null")
+      assert(row3.isNullAt(2), "value should be null")
+
+      val row4 = result.filter("id = 4").collect()(0)
+      assert(row4.isNullAt(1), "name should be null")
+      assert(row4.isNullAt(2), "value should be null")
+    }
+  }
+
+  test("write empty dataframe") {
+    withTable("empty_db", "test_empty", testSchema) {
+      // Create empty DataFrame with proper schema
+      val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
+        .toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "empty_db"), "table" -> "test_empty")
+
+      // Should not fail
+      emptyData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 0, "Table should be empty")
+    }
+  }
+
+  test("order by with nullable columns using allow_nullable_key setting") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "ordered_db"
+    val tableName = "test_ordered_nullable"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(3), Some("C"), 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (Some(1), Some("A"), 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (None, Some("B"), 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (Some(2), None, 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "category", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id, category",
+          "settings.allow_nullable_key" -> "1"
+        )
+
+      // This should succeed because allow_nullable_key is enabled
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify all data is present
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "A", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+
+      // Verify null values are preserved
+      val nullIdRow = result.filter("id IS NULL").collect()
+      assert(nullIdRow.length == 1, "Should have one row with null id")
+      assert(nullIdRow(0).isNullAt(0), "id should be null")
+      assert(nullIdRow(0).getString(1) == "B", "category should be B")
+
+      val nullCategoryRow = result.filter("category IS NULL").collect()
+      assert(nullCategoryRow.length == 1, "Should have one row with null category")
+      assert(nullCategoryRow(0).getInt(0) == 2, "id should be 2")
+      assert(nullCategoryRow(0).isNullAt(1), "category should be null")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("order by without allow_nullable_key setting should fail on nullable columns") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "fail_ordered_db"
+    val tableName = "test_fail_ordered"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(1), "Alice", 95.5),
+        (Some(2), "Bob", 87.3)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id",
+          "settings.allow_nullable_key" -> "0"
+        )
+
+      // This should fail because ORDER BY on nullable column with allow_nullable_key disabled
+      val exception = intercept[Exception] {
+        writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("Sorting key") ||
+          exception.getMessage.contains("nullable") ||
+          exception.getMessage.contains("allow_nullable_key"),
+        s"Expected error about nullable sorting key, got: ${exception.getMessage}"
+      )
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+}

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -171,7 +171,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     db: String,
     tbl: String,
     writeData: Boolean = false
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -210,7 +210,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
           .append
       }
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-3.5/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.5/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.5/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-3.5/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -115,6 +115,7 @@ case class ClickHouseTable(
       BATCH_READ,
       BATCH_WRITE,
       TRUNCATE,
+      OVERWRITE_BY_FILTER,
       ACCEPT_ANY_SCHEMA // TODO check schema and handle extra columns before writing
     ).asJava
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -205,10 +205,14 @@ class ClickHouseTableProvider extends TableProvider
       Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
       Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
     ) ++ (
-      if (optionsMap.contains("ssl")) {
-        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      if (optionsMap.contains(Constants.CATALOG_PROP_TZ)) {
+        Map(Constants.CATALOG_PROP_TZ -> optionsMap(Constants.CATALOG_PROP_TZ))
       } else {
         Map.empty[String, String]
+      }
+    ) ++ (
+      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+        case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clickhouse.spark
+
+import com.clickhouse.spark.client.NodeClient
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * TableProvider implementation for ClickHouse, enabling format-based access pattern:
+ * {{{
+ *   spark.read
+ *     .format("clickhouse")
+ *     .option("host", "localhost")
+ *     .option("database", "default")
+ *     .option("table", "my_table")
+ *     .load()
+ * }}}
+ *
+ * This implementation delegates to ClickHouseCatalog for all operations,
+ * ensuring consistent behavior between catalog and format APIs.
+ *
+ * Particularly useful for:
+ * - Ad-hoc queries without catalog configuration
+ * - Databricks Unity Catalog environments
+ * - Simple ETL pipelines
+ * - Multi-cluster access patterns
+ */
+class ClickHouseTableProvider extends TableProvider
+    with DataSourceRegister
+    with ClickHouseHelper {
+
+  override def shortName(): String = "clickhouse"
+
+  /**
+   * Infer schema from ClickHouse table.
+   *
+   * Required options:
+   * - host: ClickHouse host
+   * - database: Database name
+   * - table: Table name
+   *
+   * Optional options:
+   * - protocol: http (default), https, grpc
+   * - http_port: HTTP port (default: 8123)
+   * - user: Username (default: "default")
+   * - password: Password (default: empty)
+   * - ssl: Enable SSL (default: false)
+   * - timezone: Timezone (default: "server")
+   */
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    log.info(s"Inferring schema for ClickHouse with options: ${options.asCaseSensitiveMap()}")
+
+    // Infer schema from table using catalog
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+    try {
+      val table = catalog.loadTable(identifier)
+      log.info(s"Inferred schema from table with ${table.schema.fields.length} fields")
+      table.schema
+    } finally {
+      // Catalog manages its own resources via NodeClient
+    }
+  }
+
+  override def getTable(
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    log.info(s"Getting ClickHouse table with schema: ${schema.simpleString}")
+
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+
+    loadOrCreateTable(catalog, identifier, schema, partitioning, properties)
+  }
+
+  private def loadOrCreateTable(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table =
+    try
+      catalog.loadTable(identifier)
+    catch {
+      case _: NoSuchTableException =>
+        log.info(s"Table $identifier does not exist, creating with provided schema")
+        createTableWithOrderBy(catalog, identifier, schema, partitioning, properties)
+    }
+
+  private def createTableWithOrderBy(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    import scala.collection.JavaConverters._
+    val propsMap = properties.asScala.toMap
+    val updatedProps = ensureOrderByConfiguration(schema, propsMap)
+    catalog.createTable(identifier, schema, partitioning, updatedProps.asJava)
+  }
+
+  private def ensureOrderByConfiguration(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val hasOrderBy = props.contains("order_by") || props.contains("local.order_by")
+
+    if (!hasOrderBy) {
+      addDefaultOrderBy(schema, props)
+    } else {
+      ensureNullableKeySupport(schema, props)
+    }
+  }
+
+  private def addDefaultOrderBy(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    log.info(s"Schema fields: ${schema.fields.map(f => s"${f.name}(nullable=${f.nullable})").mkString(", ")}")
+
+    val orderByColumn = schema.fields
+      .find(!_.nullable)
+      .map(_.name)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "Cannot auto-generate ORDER BY clause: all columns are nullable. " +
+            "ClickHouse Cloud requires non-nullable columns in ORDER BY. " +
+            "Please either: (1) make at least one column non-nullable, or " +
+            "(2) explicitly set 'order_by' option to specify which column(s) to use."
+        )
+      }
+
+    log.info(s"Auto-generated ORDER BY clause: $orderByColumn")
+    props + ("order_by" -> orderByColumn)
+  }
+
+  private def ensureNullableKeySupport(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val orderByColumns = props
+      .getOrElse("order_by", props.getOrElse("local.order_by", ""))
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    val hasNullableOrderByColumn = orderByColumns.exists { colName =>
+      schema.fields.find(_.name.equalsIgnoreCase(colName)).exists(_.nullable)
+    }
+
+    if (hasNullableOrderByColumn && !props.contains("settings.allow_nullable_key")) {
+      log.info("ORDER BY contains nullable columns, adding settings.allow_nullable_key=1")
+      props + ("settings.allow_nullable_key" -> "1")
+    } else {
+      props
+    }
+  }
+
+  override def supportsExternalMetadata(): Boolean = true
+
+  private def extractIdentifier(options: CaseInsensitiveStringMap): Identifier = {
+    val database = options.getOrDefault("database", "default")
+    val table = options.get("table")
+
+    if (table == null || table.isEmpty) {
+      throw new IllegalArgumentException(
+        "Required option 'table' is missing. Please provide it via .option('table', 'value')"
+      )
+    }
+
+    Identifier.of(Array(database), table)
+  }
+
+  private def createCatalog(options: CaseInsensitiveStringMap): ClickHouseCatalog = {
+    import scala.collection.JavaConverters._
+
+    val catalog = new ClickHouseCatalog()
+
+    val optionsMap = options.asCaseSensitiveMap().asScala.toMap
+    val normalizedOptions = optionsMap ++ Map(
+      Constants.CATALOG_PROP_HOST -> optionsMap.getOrElse("host", ""),
+      Constants.CATALOG_PROP_DATABASE -> optionsMap.getOrElse("database", "default"),
+      Constants.CATALOG_PROP_HTTP_PORT -> optionsMap.getOrElse("http_port", "8123"),
+      Constants.CATALOG_PROP_PROTOCOL -> optionsMap.getOrElse("protocol", "http"),
+      Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
+      Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
+    ) ++ (
+      if (optionsMap.contains("ssl")) {
+        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      } else {
+        Map.empty[String, String]
+      }
+    )
+
+    catalog.initialize("_temp_catalog", new CaseInsensitiveStringMap(normalizedOptions.asJava))
+
+    catalog
+  }
+}

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -211,7 +211,7 @@ class ClickHouseTableProvider extends TableProvider
         Map.empty[String, String]
       }
     ) ++ (
-      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+      optionsMap.filter { case (key, _) => key == "ssl" || key == "ssl_mode" }.map {
         case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -62,6 +62,8 @@ class ClickHouseWrite(
     with SQLConfHelper
     with Logging {
 
+  override def distributionStrictlyRequired: Boolean = writeJob.writeOptions.repartitionStrictly
+
   override def description: String =
     s"ClickHouseWrite(database=${writeJob.targetDatabase(false)}, table=${writeJob.targetTable(false)})})"
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -49,14 +49,6 @@ class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
       case _: AlwaysTrue => true
       case _ => false
     }
-
-    if (hasPartitionFilters) {
-      log.warn(
-        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
-      )
-    } else {
-      log.info("Full table overwrite (no partition filters)")
-    }
     this
   }
 }
@@ -112,11 +104,9 @@ class ClickHouseBatchWrite(
       writeJob.tableEngineSpec match {
         case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
           val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
         case _ =>
           val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
       }
     }

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -17,26 +17,58 @@ package com.clickhouse.spark.write
 import com.clickhouse.spark.{BytesWrittenMetric, RecordsWrittenMetric, SerializeTimeMetric, WriteTimeMetric}
 import com.clickhouse.spark.exception.CHClientException
 import com.clickhouse.spark.write.format.{ClickHouseArrowStreamWriter, ClickHouseJsonEachRowWriter}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
 import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
 import org.apache.spark.sql.connector.expressions.SortOrder
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.write._
+import org.apache.spark.sql.sources.Filter
 import com.clickhouse.spark._
+import com.clickhouse.spark.spec.DistributedEngineSpec
+import org.apache.spark.sql.sources.AlwaysTrue
 
-class ClickHouseWriteBuilder(writeJob: WriteJobDescription) extends WriteBuilder {
+class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
+    extends WriteBuilder
+    with SupportsOverwrite
+    with Logging {
 
-  override def build(): Write = new ClickHouseWrite(writeJob)
+  private var isOverwrite: Boolean = false
+  private var overwriteFilters: Array[Filter] = Array.empty
+
+  override def build(): Write = new ClickHouseWrite(writeJob, isOverwrite, overwriteFilters)
+
+  override def overwrite(filters: Array[Filter]): WriteBuilder = {
+    log.info(s"Overwrite mode for table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)}")
+    isOverwrite = true
+    overwriteFilters = filters
+
+    // Check if we have actual partition filters (not AlwaysTrue or empty)
+    val hasPartitionFilters = filters.nonEmpty && !filters.forall {
+      case _: AlwaysTrue => true
+      case _ => false
+    }
+
+    if (hasPartitionFilters) {
+      log.warn(
+        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
+      )
+    } else {
+      log.info("Full table overwrite (no partition filters)")
+    }
+    this
+  }
 }
 
 class ClickHouseWrite(
-  writeJob: WriteJobDescription
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false,
+  overwriteFilters: Array[Filter] = Array.empty
 ) extends Write
     with RequiresDistributionAndOrdering
-    with SQLConfHelper {
-
-  override def distributionStrictlyRequired: Boolean = writeJob.writeOptions.repartitionStrictly
+    with SQLConfHelper
+    with Logging {
 
   override def description: String =
     s"ClickHouseWrite(database=${writeJob.targetDatabase(false)}, table=${writeJob.targetTable(false)})})"
@@ -47,7 +79,7 @@ class ClickHouseWrite(
 
   override def requiredOrdering(): Array[SortOrder] = writeJob.sparkSortOrders
 
-  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob)
+  override def toBatch: BatchWrite = new ClickHouseBatchWrite(writeJob, isOverwrite)
 
   override def supportedCustomMetrics(): Array[CustomMetric] = Array(
     RecordsWrittenMetric(),
@@ -58,10 +90,37 @@ class ClickHouseWrite(
 }
 
 class ClickHouseBatchWrite(
-  writeJob: WriteJobDescription
-) extends BatchWrite with DataWriterFactory {
+  writeJob: WriteJobDescription,
+  isOverwrite: Boolean = false
+) extends BatchWrite with DataWriterFactory with Logging {
 
-  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = this
+  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+    // Truncate table before writing if overwrite mode is enabled
+    if (isOverwrite) {
+      truncateTable()
+    }
+    this
+  }
+
+  private def truncateTable(): Unit = {
+    import com.clickhouse.spark.client.NodeClient
+    import com.clickhouse.spark.Utils
+
+    log.info(s"Truncating table ${writeJob.targetDatabase(false)}.${writeJob.targetTable(false)} for overwrite mode")
+
+    Utils.tryWithResource(NodeClient(writeJob.node)) { implicit nodeClient =>
+      writeJob.tableEngineSpec match {
+        case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+        case _ =>
+          val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
+          log.info(s"Executing: $sql")
+          nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
+      }
+    }
+  }
 
   override def commit(messages: Array[WriterCommitMessage]): Unit = {}
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
@@ -63,24 +63,43 @@ case class WriteJobDescription(
     case _ => None
   }
 
-  def sparkSplits: Array[Transform] =
-    if (writeOptions.repartitionByPartition) {
-      ExprUtils.toSparkSplits(
-        shardingKeyIgnoreRand,
-        partitionKey,
-        functionRegistry
-      )
+  // For SharedMergeTree, filter out unsupported partition expressions while keeping supported ones.
+  private lazy val isSharedMergeTree: Boolean =
+    tableEngineSpec.engine_clause.toLowerCase.contains("sharedmergetree")
+
+  private def filterSupportedPartitionExprs(exprs: Option[List[Expr]]): Option[List[Expr]] = {
+    if (!isSharedMergeTree) return exprs
+    exprs.map(_.flatMap { expr =>
+      ExprUtils.toSparkTransformOpt(expr, functionRegistry).map(_ => expr)
+    })
+  }
+
+  def sparkSplits: Array[Transform] = {
+    val _partitionKey = if (writeOptions.repartitionByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
     } else {
-      ExprUtils.toSparkSplits(
-        shardingKeyIgnoreRand,
-        None,
-        functionRegistry
-      )
+      None
     }
+    ExprUtils.toSparkSplits(
+      shardingKeyIgnoreRand,
+      _partitionKey,
+      functionRegistry
+    )
+  }
 
   def sparkSortOrders: Array[SortOrder] = {
-    val _partitionKey = if (writeOptions.localSortByPartition) partitionKey else None
+    val _partitionKey = if (writeOptions.localSortByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
+    } else {
+      None
+    }
     val _sortingKey = if (writeOptions.localSortByKey) sortingKey else None
-    ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, _partitionKey, _sortingKey, cluster, functionRegistry)
+    ExprUtils.toSparkSortOrders(
+      shardingKeyIgnoreRand,
+      _partitionKey,
+      _sortingKey,
+      cluster,
+      functionRegistry
+    )
   }
 }

--- a/spark-4.0/build.gradle
+++ b/spark-4.0/build.gradle
@@ -44,16 +44,23 @@ project(":clickhouse-spark-runtime-${spark_binary_version}_$scala_binary_version
             exclude group: "org.slf4j", module: "slf4j-api"
             exclude group: "org.apache.commons", module: "commons-lang3"
             exclude group: "com.clickhouse", module: "clickhouse-jdbc"
-            exclude group: "com.fasterxml.jackson.core"
-            exclude group: "com.fasterxml.jackson.datatype"
-            exclude group: "com.fasterxml.jackson.module"
         }
+
+        // Include Jackson dependencies to be bundled and shaded in the runtime jar
+        // This ensures we use our version and avoid conflicts with external versions (e.g., Databricks Hudi)
+        implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
+        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
+        implementation "com.fasterxml.jackson.module:jackson-module-scala_$scala_binary_version:$jackson_version"
     }
 
     shadowJar {
         zip64=true
         archiveClassifier=null
 
+        // Relocate Jackson classes to avoid conflicts with external versions (e.g., from Databricks Hudi)
+        // This ensures we use our bundled Jackson version and prevents class conflicts.
+        relocate "com.fasterxml.jackson", "com.clickhouse.spark.shaded.jackson"
+        
         mergeServiceFiles()
     }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -14,7 +14,7 @@
 
 package org.apache.spark.sql.clickhouse.single
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types._
 
 /**
@@ -25,6 +25,60 @@ import org.apache.spark.sql.types._
  * Each type includes comprehensive coverage of edge cases and null handling.
  */
 trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
+
+  /**
+   * Reads a table using both the Catalog API and TableProvider API,
+   * verifies they return the same data, and returns the DataFrame.
+   * 
+   * @param db Database name
+   * @param tbl Table name
+   * @param columns Column selection (default: "*")
+   * @param orderBy Optional ORDER BY clause
+   * @return DataFrame from the Catalog API
+   */
+  def readTableWithBothAPIs(
+    db: String,
+    tbl: String,
+    columns: String = "*",
+    orderBy: Option[String] = None
+  ): DataFrame = {
+    import org.apache.spark.sql.functions.col
+
+    val catalogQuery = orderBy match {
+      case Some(order) => s"SELECT $columns FROM $db.$tbl ORDER BY $order"
+      case None => s"SELECT $columns FROM $db.$tbl"
+    }
+    val catalogDF = spark.sql(catalogQuery)
+
+    val tableProviderDFBase = spark.read
+      .format("clickhouse")
+      .option("host", clickhouseHost)
+      .option("http_port", clickhouseHttpPort.toString)
+      .option("protocol", "http")
+      .option("user", clickhouseUser)
+      .option("password", clickhousePassword)
+      .option("database", db)
+      .option("table", tbl)
+      .load()
+
+    val tableProviderDFSelected = if (columns == "*") {
+      tableProviderDFBase
+    } else {
+      val columnList = columns.split(",").map(_.trim)
+      tableProviderDFBase.select(columnList.map(col): _*)
+    }
+
+    val tableProviderDF = orderBy match {
+      case Some(order) =>
+        val orderColumns = order.split(",").map(_.trim).map(col)
+        tableProviderDFSelected.orderBy(orderColumns: _*)
+      case None => tableProviderDFSelected
+    }
+
+    checkAnswer(catalogDF, tableProviderDF.collect())
+
+    catalogDF
+  }
 
   // ============================================================================
   // ArrayType Tests
@@ -40,7 +94,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_array_int ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getSeq[Int](1) == Seq(1, 2, 3))
@@ -59,7 +113,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_array_string ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getSeq[String](1) == Seq("hello", "world"))
@@ -78,7 +132,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_array_nullable ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         // Verify arrays can be read
@@ -97,7 +151,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_empty_array ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getSeq[Int](1).isEmpty)
@@ -116,7 +170,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_nested_array ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         // Verify nested arrays can be read
@@ -136,7 +190,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_fixedstring ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 2)
         // FixedString should be readable
@@ -155,7 +209,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_fixedstring_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).get(1) != null)
@@ -180,7 +234,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_bool ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 4)
       // Check the value - handle both Boolean (JSON) and Short (Binary) formats
@@ -211,7 +265,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_bool_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(1).isNullAt(1))
@@ -243,7 +297,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_byte ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -128.toByte) :: Row(2, 0.toByte) :: Row(3, 127.toByte) :: Nil
@@ -260,7 +314,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_byte_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -128.toByte) :: Row(2, null) :: Row(3, 127.toByte) :: Nil
@@ -276,7 +330,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime32 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 2)
       assert(result(0).getTimestamp(1) != null)
@@ -294,7 +348,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime32_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getTimestamp(1) != null)
@@ -312,7 +366,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_date ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getDate(1) != null)
@@ -330,7 +384,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_date32 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getDate(1) != null)
@@ -349,7 +403,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_date32_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDate(1) != null)
@@ -367,7 +421,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_date_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getDate(1) != null)
@@ -387,7 +441,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal128 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       // Decimal128(20) means 20 decimal places, total precision up to 38 digits
@@ -407,7 +461,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal128_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1) != null)
@@ -425,7 +479,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal32 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getDecimal(1).doubleValue() == 12345.6789)
@@ -444,7 +498,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal32_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1) != null)
@@ -464,7 +518,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal64 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(math.abs(result(0).getDecimal(1).doubleValue() - 1234567.0123456789) < 0.0001)
@@ -483,7 +537,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_decimal64_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1) != null)
@@ -502,7 +556,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_double_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(math.abs(result(0).getDouble(1) - 1.23) < 0.0001)
@@ -520,7 +574,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_double ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(math.abs(result(0).getDouble(1) - -3.141592653589793) < 0.000001)
@@ -539,7 +593,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_enum16 ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getString(1) == "small")
@@ -561,7 +615,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_enum16_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) == "small")
@@ -580,7 +634,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_enum8_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getString(1) == "red")
@@ -599,7 +653,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_enum8 ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getString(1) == "red")
@@ -618,7 +672,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_float_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(math.abs(result(0).getFloat(1) - 1.5f) < 0.01f)
@@ -636,7 +690,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_float ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(math.abs(result(0).getFloat(1) - -3.14f) < 0.01f)
@@ -654,7 +708,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int128 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -673,7 +727,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int128_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -692,7 +746,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int256_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -709,7 +763,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int256 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 2)
       assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -726,7 +780,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -2147483648) :: Row(2, 0) :: Row(3, 2147483647) :: Nil
@@ -743,7 +797,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_int_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -2147483648) :: Row(2, null) :: Row(3, 2147483647) :: Nil
@@ -760,7 +814,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_ipv4 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) == "127.0.0.1")
@@ -778,7 +832,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_ipv4_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) == "127.0.0.1")
@@ -796,7 +850,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_ipv6 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) != null)
@@ -814,7 +868,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_ipv6_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) != null)
@@ -833,7 +887,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
             |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_json_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getString(1).contains("Alice"))
@@ -851,7 +905,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
           |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_json ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1).contains("Alice"))
@@ -869,7 +923,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_long ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -9223372036854775808L) :: Row(2, 0L) :: Row(3, 9223372036854775807L) :: Nil
@@ -886,7 +940,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_long_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -9223372036854775808L) :: Row(2, null) :: Row(3, 9223372036854775807L) :: Nil
@@ -904,7 +958,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint32_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         checkAnswer(
           df,
           Row(1, 0L) :: Row(2, null) :: Row(3, 4294967295L) :: Nil
@@ -921,7 +975,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint32 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, 0L) :: Row(2, 2147483648L) :: Row(3, 4294967295L) :: Nil
@@ -938,7 +992,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_map ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getMap[String, Int](1) == Map("a" -> 1, "b" -> 2))
@@ -957,7 +1011,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_map_nullable ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         // Verify maps can be read
@@ -976,7 +1030,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_short ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, -32768.toShort) :: Row(2, 0.toShort) :: Row(3, 32767.toShort) :: Nil
@@ -994,7 +1048,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_short_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         checkAnswer(
           df,
           Row(1, -32768.toShort) :: Row(2, null) :: Row(3, 32767.toShort) :: Nil
@@ -1012,7 +1066,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint8_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         checkAnswer(
           df,
           Row(1, 0.toShort) :: Row(2, null) :: Row(3, 255.toShort) :: Nil
@@ -1029,7 +1083,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint8 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, 0.toShort) :: Row(2, 128.toShort) :: Row(3, 255.toShort) :: Nil
@@ -1046,7 +1100,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_empty_string ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) == "")
@@ -1065,7 +1119,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_string_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         checkAnswer(
           df,
           Row(1, "hello") :: Row(2, null) :: Row(3, "world") :: Nil
@@ -1083,7 +1137,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_string ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$$%^&*()") :: Nil
@@ -1099,7 +1153,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uuid ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 2)
       assert(result(0).getString(1) == "550e8400-e29b-41d4-a716-446655440000")
@@ -1116,7 +1170,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uuid_null ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getString(1) == "550e8400-e29b-41d4-a716-446655440000")
@@ -1133,7 +1187,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_long_string ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 1)
       assert(result(0).getString(1).length == 10000)
@@ -1149,7 +1203,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getTimestamp(1) != null)
@@ -1167,7 +1221,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime64 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 3)
       assert(result(0).getTimestamp(1) != null)
@@ -1186,7 +1240,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime64_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getTimestamp(1) != null)
@@ -1205,7 +1259,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_datetime_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getTimestamp(1) != null)
@@ -1222,7 +1276,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint128 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 2)
       assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -1240,7 +1294,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint128_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -1259,7 +1313,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint16_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         checkAnswer(
           df,
           Row(1, 0) :: Row(2, null) :: Row(3, 65535) :: Nil
@@ -1276,7 +1330,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint16 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
         Row(1, 0) :: Row(2, 32768) :: Row(3, 65535) :: Nil
@@ -1294,7 +1348,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint256_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 3)
         assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -1311,7 +1365,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint256 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 2)
       assert(result(0).getDecimal(1).toBigInteger.longValue == 0L)
@@ -1331,7 +1385,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
              |""".stripMargin
         )
 
-        val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint64_null ORDER BY key")
+        val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 5)
         assert(result(0).getDecimal(1) == BigDecimal(0))
@@ -1357,7 +1411,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
            |""".stripMargin
       )
 
-      val df = spark.sql(s"SELECT key, value FROM $actualDb.test_uint64 ORDER BY key")
+      val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 6)
       assert(result(0).getDecimal(1) == BigDecimal(0))
@@ -1405,7 +1459,8 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
 
       // Read via Spark - should infer schema with field names _1, _2, _3
-      val result = spark.table(s"$db.$tbl").sort("id").collect()
+      val df = readTableWithBothAPIs(db, tbl, columns = "*", orderBy = Some("id"))
+      val result = df.collect()
 
       assert(result.length === 3)
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -254,6 +254,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
            |WHERE type = 'QueryFinish' 
            |  AND query LIKE '%$dbName%test_filter%'
            |  AND query LIKE '%SELECT%'
+           |  AND query LIKE '%name%'
            |  AND event_time > now() - INTERVAL 10 SECOND
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -1,0 +1,492 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse.single
+
+import com.clickhouse.spark.base.ClickHouseSingleMixIn
+import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.types._
+
+class ClickHouseSingleTableProviderSuite extends ClickHouseTableProviderSuite with ClickHouseSingleMixIn
+
+/**
+ * Test suite for ClickHouse DataSource V2 TableProvider write capabilities.
+ * Tests format API, write modes, predicate pushdown, and partition overwrite.
+ */
+abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
+
+  import testImplicits._
+
+  private val testSchema = StructType(Seq(
+    StructField("id", IntegerType, nullable = false),
+    StructField("name", StringType, nullable = false),
+    StructField("value", DoubleType, nullable = false),
+    StructField("created", TimestampType, nullable = false)
+  ))
+
+  test("write and read using format API") {
+    withTable("format_api_db", "test_format_api", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      writeData.write
+        .format("clickhouse")
+        .mode(SaveMode.Append)
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .save()
+
+      val readData = spark.read
+        .format("clickhouse")
+        .options(cmdRunnerOptions)
+        .option("database", if (useSuiteLevelDatabase) testDatabaseName else "format_api_db")
+        .option("table", "test_format_api")
+        .load()
+
+      // Verify schema
+      assert(readData.schema.length == 4)
+      assert(readData.schema.fieldNames.contains("id"))
+      assert(readData.schema.fieldNames.contains("name"))
+
+      // Verify data
+      checkAnswer(
+        readData.orderBy("id"),
+        writeData.orderBy("id")
+      )
+
+      // Verify count
+      assert(readData.count() == 3)
+    }
+  }
+
+  test("append mode adds data without replacing existing") {
+    withTable("append_db", "test_append", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "append_db"), "table" -> "test_append")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val appendData = Seq(
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      appendData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+
+      assert(result.count() == 4)
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+      checkAnswer(
+        result.filter("id = 4"),
+        Row(4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")) :: Nil
+      )
+    }
+  }
+
+  test("schema inference works correctly") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "schema_db"
+    val tableName = "test_schema"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> dbName, "table" -> tableName, "order_by" -> "id")
+
+      // Let the TableProvider create the table from the DataFrame schema
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      // Read back and verify schema inference
+      val inferredDF = spark.read.format("clickhouse").options(options).load()
+
+      assert(inferredDF.schema("id").dataType == IntegerType)
+      assert(inferredDF.schema("name").dataType == StringType)
+      assert(inferredDF.schema("value").dataType == DoubleType)
+      assert(inferredDF.schema("created").dataType == TimestampType)
+
+      // Verify table was actually created
+      assert(inferredDF.count() == 1, "Should have 1 row")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("predicate pushdown filters data server-side") {
+    withTable("filter_db", "test_filter", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (3, "Charlie", 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (4, "David", 88.7, timestamp("2024-04-05T11:20:00Z")),
+        (5, "Eve", 91.2, timestamp("2024-05-12T16:45:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "filter_db"), "table" -> "test_filter")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val filtered1 = spark.read.format("clickhouse").options(options).load().filter("value > 90")
+      val result1 = filtered1.collect() // Force execution
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "filter_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      val hasFilter = recentQueries.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90")
+      )
+      assert(
+        hasFilter,
+        s"Query should contain WHERE clause with 'value > 90' filter. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(result1.length == 3)
+      checkAnswer(
+        filtered1.select("id").orderBy("id"),
+        Seq(Row(1), Row(3), Row(5))
+      )
+
+      val filtered2 = spark.read.format("clickhouse").options(options).load().filter("name = 'Bob'")
+      val result2 = filtered2.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries2DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries2 = recentQueries2DF.collect().map(_.getString(0))
+
+      val hasNameFilter = recentQueries2.exists(query =>
+        query.contains("WHERE") && query.contains("`name` = 'Bob'")
+      )
+      assert(
+        hasNameFilter,
+        s"Query should contain WHERE clause with 'name = Bob' filter. Recent queries: ${recentQueries2.mkString("; ")}"
+      )
+
+      assert(result2.length == 1)
+      checkAnswer(filtered2, Row(2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")) :: Nil)
+
+      val filtered3 = spark.read.format("clickhouse").options(options).load()
+        .filter("value > 90 AND id < 5")
+      val result3 = filtered3.collect()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val recentQueries3DF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_filter%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries3 = recentQueries3DF.collect().map(_.getString(0))
+
+      val hasCombinedFilter = recentQueries3.exists(query =>
+        query.contains("WHERE") && query.contains("`value` > 90") && query.contains("`id` < 5")
+      )
+      assert(
+        hasCombinedFilter,
+        s"Query should contain WHERE clause with 'value > 90 AND id < 5' filters. Recent queries: ${recentQueries3.mkString("; ")}"
+      )
+
+      assert(result3.length == 2)
+      checkAnswer(
+        filtered3.select("name").orderBy("id"),
+        Seq(Row("Alice"), Row("Charlie"))
+      )
+    }
+  }
+
+  test("column pruning reduces data transfer") {
+    withTable("prune_db", "test_prune", testSchema) {
+      val writeData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "prune_db"), "table" -> "test_prune")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val selected = spark.read.format("clickhouse").options(options).load().select("id", "name")
+      selected.show()
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+
+      val dbName = if (useSuiteLevelDatabase) testDatabaseName else "prune_db"
+      val recentQueriesDF = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log 
+           |WHERE type = 'QueryFinish' 
+           |  AND query LIKE '%$dbName%test_prune%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 10 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      )
+
+      val recentQueries = recentQueriesDF.collect().map(_.getString(0))
+
+      // Check that the query only selects id and name columns, not value or created
+      val hasPrunedColumns = recentQueries.exists(query =>
+        query.contains("SELECT") &&
+          query.contains("`id`") &&
+          query.contains("`name`") &&
+          !query.contains("`value`") &&
+          !query.contains("`created`")
+      )
+      assert(
+        hasPrunedColumns,
+        s"Query should only SELECT id and name columns, not value or created. Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      assert(selected.schema.length == 2)
+      assert(selected.schema.fieldNames.contains("id"))
+      assert(selected.schema.fieldNames.contains("name"))
+      assert(!selected.schema.fieldNames.contains("value"))
+      assert(!selected.schema.fieldNames.contains("created"))
+
+      checkAnswer(
+        selected.orderBy("id"),
+        Seq(Row(1, "Alice"), Row(2, "Bob"))
+      )
+    }
+  }
+
+  test("error if exists mode is not supported") {
+    withTable("error_db", "test_error", testSchema) {
+      val initialData = Seq(
+        (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "error_db"), "table" -> "test_error")
+
+      initialData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val newData = Seq(
+        (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
+      ).toDF("id", "name", "value", "created")
+
+      val exception = intercept[Exception] {
+        newData.write.format("clickhouse").mode(SaveMode.ErrorIfExists).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("UNSUPPORTED_DATA_SOURCE_SAVE_MODE") ||
+          exception.getMessage.contains("ErrorIfExists"),
+        s"Expected error about unsupported save mode, got: ${exception.getMessage}"
+      )
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 1)
+      checkAnswer(result, Row(1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil)
+    }
+  }
+
+  test("write with null values") {
+    val nullableSchema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = true),
+      StructField("value", DoubleType, nullable = true)
+    ))
+
+    withTable("null_db", "test_nulls", nullableSchema) {
+      val writeData = Seq(
+        (1, Some("Alice"), Some(95.5)),
+        (2, None, Some(87.3)),
+        (3, Some("Charlie"), None),
+        (4, None, None)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "null_db"), "table" -> "test_nulls")
+
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify null values preserved
+      val row2 = result.filter("id = 2").collect()(0)
+      assert(row2.isNullAt(1), "name should be null")
+      assert(!row2.isNullAt(2), "value should not be null")
+
+      val row3 = result.filter("id = 3").collect()(0)
+      assert(!row3.isNullAt(1), "name should not be null")
+      assert(row3.isNullAt(2), "value should be null")
+
+      val row4 = result.filter("id = 4").collect()(0)
+      assert(row4.isNullAt(1), "name should be null")
+      assert(row4.isNullAt(2), "value should be null")
+    }
+  }
+
+  test("write empty dataframe") {
+    withTable("empty_db", "test_empty", testSchema) {
+      // Create empty DataFrame with proper schema
+      val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
+        .toDF("id", "name", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map("database" -> (if (useSuiteLevelDatabase) testDatabaseName else "empty_db"), "table" -> "test_empty")
+
+      // Should not fail
+      emptyData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 0, "Table should be empty")
+    }
+  }
+
+  test("order by with nullable columns using allow_nullable_key setting") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "ordered_db"
+    val tableName = "test_ordered_nullable"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(3), Some("C"), 92.1, timestamp("2024-03-10T09:15:00Z")),
+        (Some(1), Some("A"), 95.5, timestamp("2024-01-15T10:00:00Z")),
+        (None, Some("B"), 87.3, timestamp("2024-02-20T14:30:00Z")),
+        (Some(2), None, 88.7, timestamp("2024-04-05T11:20:00Z"))
+      ).toDF("id", "category", "value", "created")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id, category",
+          "settings.allow_nullable_key" -> "1"
+        )
+
+      // This should succeed because allow_nullable_key is enabled
+      writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+
+      val result = spark.read.format("clickhouse").options(options).load()
+      assert(result.count() == 4)
+
+      // Verify all data is present
+      checkAnswer(
+        result.filter("id = 1"),
+        Row(1, "A", 95.5, timestamp("2024-01-15T10:00:00Z")) :: Nil
+      )
+
+      // Verify null values are preserved
+      val nullIdRow = result.filter("id IS NULL").collect()
+      assert(nullIdRow.length == 1, "Should have one row with null id")
+      assert(nullIdRow(0).isNullAt(0), "id should be null")
+      assert(nullIdRow(0).getString(1) == "B", "category should be B")
+
+      val nullCategoryRow = result.filter("category IS NULL").collect()
+      assert(nullCategoryRow.length == 1, "Should have one row with null category")
+      assert(nullCategoryRow(0).getInt(0) == 2, "id should be 2")
+      assert(nullCategoryRow(0).isNullAt(1), "category should be null")
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+
+  test("order by without allow_nullable_key setting should fail on nullable columns") {
+    val dbName = if (useSuiteLevelDatabase) testDatabaseName else "fail_ordered_db"
+    val tableName = "test_fail_ordered"
+
+    try {
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$dbName`")
+      }
+
+      val writeData = Seq(
+        (Some(1), "Alice", 95.5),
+        (Some(2), "Bob", 87.3)
+      ).toDF("id", "name", "value")
+
+      val options = cmdRunnerOptions ++
+        Map(
+          "database" -> dbName,
+          "table" -> tableName,
+          "order_by" -> "id",
+          "settings.allow_nullable_key" -> "0"
+        )
+
+      // This should fail because ORDER BY on nullable column with allow_nullable_key disabled
+      val exception = intercept[Exception] {
+        writeData.write.format("clickhouse").mode(SaveMode.Append).options(options).save()
+      }
+
+      assert(
+        exception.getMessage.contains("Sorting key") ||
+          exception.getMessage.contains("nullable") ||
+          exception.getMessage.contains("allow_nullable_key"),
+        s"Expected error about nullable sorting key, got: ${exception.getMessage}"
+      )
+    } finally {
+      dropTableWithRetry(dbName, tableName)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$dbName`")
+      }
+    }
+  }
+}

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -169,7 +169,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     db: String,
     tbl: String,
     writeData: Boolean = false
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -208,7 +208,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
           .append
       }
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-4.0/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-4.0/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-4.0/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-4.0/clickhouse-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 com.clickhouse.spark.ClickHouseTableProvider

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -115,6 +115,7 @@ case class ClickHouseTable(
       BATCH_READ,
       BATCH_WRITE,
       TRUNCATE,
+      OVERWRITE_BY_FILTER,
       ACCEPT_ANY_SCHEMA // TODO check schema and handle extra columns before writing
     ).asJava
 

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -68,7 +68,6 @@ class ClickHouseTableProvider extends TableProvider
    * - timezone: Timezone (default: "server")
    */
   override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
-    log.info(s"Inferring schema for ClickHouse with options: ${options.asCaseSensitiveMap()}")
 
     // Infer schema from table using catalog
     val catalog = createCatalog(options)

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clickhouse.spark
+
+import com.clickhouse.spark.client.NodeClient
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+/**
+ * TableProvider implementation for ClickHouse, enabling format-based access pattern:
+ * {{{
+ *   spark.read
+ *     .format("clickhouse")
+ *     .option("host", "localhost")
+ *     .option("database", "default")
+ *     .option("table", "my_table")
+ *     .load()
+ * }}}
+ *
+ * This implementation delegates to ClickHouseCatalog for all operations,
+ * ensuring consistent behavior between catalog and format APIs.
+ *
+ * Particularly useful for:
+ * - Ad-hoc queries without catalog configuration
+ * - Databricks Unity Catalog environments
+ * - Simple ETL pipelines
+ * - Multi-cluster access patterns
+ */
+class ClickHouseTableProvider extends TableProvider
+    with DataSourceRegister
+    with ClickHouseHelper {
+
+  override def shortName(): String = "clickhouse"
+
+  /**
+   * Infer schema from ClickHouse table.
+   *
+   * Required options:
+   * - host: ClickHouse host
+   * - database: Database name
+   * - table: Table name
+   *
+   * Optional options:
+   * - protocol: http (default), https, grpc
+   * - http_port: HTTP port (default: 8123)
+   * - user: Username (default: "default")
+   * - password: Password (default: empty)
+   * - ssl: Enable SSL (default: false)
+   * - timezone: Timezone (default: "server")
+   */
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    log.info(s"Inferring schema for ClickHouse with options: ${options.asCaseSensitiveMap()}")
+
+    // Infer schema from table using catalog
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+    try {
+      val table = catalog.loadTable(identifier)
+      log.info(s"Inferred schema from table with ${table.schema.fields.length} fields")
+      table.schema
+    } finally {
+      // Catalog manages its own resources via NodeClient
+    }
+  }
+
+  override def getTable(
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    val options = new CaseInsensitiveStringMap(properties)
+    log.info(s"Getting ClickHouse table with schema: ${schema.simpleString}")
+
+    val catalog = createCatalog(options)
+    val identifier = extractIdentifier(options)
+
+    loadOrCreateTable(catalog, identifier, schema, partitioning, properties)
+  }
+
+  private def loadOrCreateTable(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table =
+    try
+      catalog.loadTable(identifier)
+    catch {
+      case _: NoSuchTableException =>
+        log.info(s"Table $identifier does not exist, creating with provided schema")
+        createTableWithOrderBy(catalog, identifier, schema, partitioning, properties)
+    }
+
+  private def createTableWithOrderBy(
+    catalog: ClickHouseCatalog,
+    identifier: Identifier,
+    schema: StructType,
+    partitioning: Array[Transform],
+    properties: util.Map[String, String]
+  ): Table = {
+    import scala.jdk.CollectionConverters._
+    val propsMap = properties.asScala.toMap
+    val updatedProps = ensureOrderByConfiguration(schema, propsMap)
+    catalog.createTable(identifier, schema, partitioning, updatedProps.asJava)
+  }
+
+  private def ensureOrderByConfiguration(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val hasOrderBy = props.contains("order_by") || props.contains("local.order_by")
+
+    if (!hasOrderBy) {
+      addDefaultOrderBy(schema, props)
+    } else {
+      ensureNullableKeySupport(schema, props)
+    }
+  }
+
+  private def addDefaultOrderBy(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    log.info(s"Schema fields: ${schema.fields.map(f => s"${f.name}(nullable=${f.nullable})").mkString(", ")}")
+
+    val orderByColumn = schema.fields
+      .find(!_.nullable)
+      .map(_.name)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "Cannot auto-generate ORDER BY clause: all columns are nullable. " +
+            "ClickHouse Cloud requires non-nullable columns in ORDER BY. " +
+            "Please either: (1) make at least one column non-nullable, or " +
+            "(2) explicitly set 'order_by' option to specify which column(s) to use."
+        )
+      }
+
+    log.info(s"Auto-generated ORDER BY clause: $orderByColumn")
+    props + ("order_by" -> orderByColumn)
+  }
+
+  private def ensureNullableKeySupport(schema: StructType, props: Map[String, String]): Map[String, String] = {
+    val orderByColumns = props
+      .getOrElse("order_by", props.getOrElse("local.order_by", ""))
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    val hasNullableOrderByColumn = orderByColumns.exists { colName =>
+      schema.fields.find(_.name.equalsIgnoreCase(colName)).exists(_.nullable)
+    }
+
+    if (hasNullableOrderByColumn && !props.contains("settings.allow_nullable_key")) {
+      log.info("ORDER BY contains nullable columns, adding settings.allow_nullable_key=1")
+      props + ("settings.allow_nullable_key" -> "1")
+    } else {
+      props
+    }
+  }
+
+  override def supportsExternalMetadata(): Boolean = true
+
+  private def extractIdentifier(options: CaseInsensitiveStringMap): Identifier = {
+    val database = options.getOrDefault("database", "default")
+    val table = options.get("table")
+
+    if (table == null || table.isEmpty) {
+      throw new IllegalArgumentException(
+        "Required option 'table' is missing. Please provide it via .option('table', 'value')"
+      )
+    }
+
+    Identifier.of(Array(database), table)
+  }
+
+  private def createCatalog(options: CaseInsensitiveStringMap): ClickHouseCatalog = {
+    import scala.jdk.CollectionConverters._
+
+    val catalog = new ClickHouseCatalog()
+
+    val optionsMap = options.asCaseSensitiveMap().asScala.toMap
+    val normalizedOptions = optionsMap ++ Map(
+      Constants.CATALOG_PROP_HOST -> optionsMap.getOrElse("host", ""),
+      Constants.CATALOG_PROP_DATABASE -> optionsMap.getOrElse("database", "default"),
+      Constants.CATALOG_PROP_HTTP_PORT -> optionsMap.getOrElse("http_port", "8123"),
+      Constants.CATALOG_PROP_PROTOCOL -> optionsMap.getOrElse("protocol", "http"),
+      Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
+      Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
+    ) ++ (
+      if (optionsMap.contains("ssl")) {
+        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      } else {
+        Map.empty[String, String]
+      }
+    )
+
+    catalog.initialize("_temp_catalog", new CaseInsensitiveStringMap(normalizedOptions.asJava))
+
+    catalog
+  }
+}

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -204,10 +204,14 @@ class ClickHouseTableProvider extends TableProvider
       Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
       Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
     ) ++ (
-      if (optionsMap.contains("ssl")) {
-        Map(Constants.CATALOG_PROP_OPTION_PREFIX + "ssl" -> optionsMap("ssl"))
+      if (optionsMap.contains("timezone")) {
+        Map(Constants.CATALOG_PROP_TZ -> optionsMap("timezone"))
       } else {
         Map.empty[String, String]
+      }
+    ) ++ (
+      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+        case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )
 

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -210,7 +210,7 @@ class ClickHouseTableProvider extends TableProvider
         Map.empty[String, String]
       }
     ) ++ (
-      optionsMap.view.filterKeys(key => key == "ssl" || key == "ssl_mode").toMap.map {
+      optionsMap.filter { case (key, _) => key == "ssl" || key == "ssl_mode" }.map {
         case (key, value) => Constants.CATALOG_PROP_OPTION_PREFIX + key -> value
       }
     )

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -127,29 +127,33 @@ class ClickHouseTableProvider extends TableProvider
     val hasOrderBy = props.contains("order_by") || props.contains("local.order_by")
 
     if (!hasOrderBy) {
-      addDefaultOrderBy(schema, props)
-    } else {
-      ensureNullableKeySupport(schema, props)
+      throw new IllegalArgumentException(
+        "Required option 'order_by' is missing when creating a new table. " +
+          "Please provide it via .option('order_by', 'column_name') or .option('order_by', 'col1, col2'). " +
+          "The ORDER BY clause specifies the sorting key for the ClickHouse table."
+      )
     }
-  }
 
-  private def addDefaultOrderBy(schema: StructType, props: Map[String, String]): Map[String, String] = {
-    log.info(s"Schema fields: ${schema.fields.map(f => s"${f.name}(nullable=${f.nullable})").mkString(", ")}")
+    // Validate that order_by columns exist in the schema
+    val orderByKey = props.getOrElse("order_by", props.getOrElse("local.order_by", ""))
+    val orderByColumns = orderByKey
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
 
-    val orderByColumn = schema.fields
-      .find(!_.nullable)
-      .map(_.name)
-      .getOrElse {
-        throw new IllegalArgumentException(
-          "Cannot auto-generate ORDER BY clause: all columns are nullable. " +
-            "ClickHouse Cloud requires non-nullable columns in ORDER BY. " +
-            "Please either: (1) make at least one column non-nullable, or " +
-            "(2) explicitly set 'order_by' option to specify which column(s) to use."
-        )
-      }
+    val schemaFieldNames = schema.fields.map(_.name).toSet
+    val missingColumns = orderByColumns.filterNot(colName =>
+      schemaFieldNames.exists(_.equalsIgnoreCase(colName))
+    )
 
-    log.info(s"Auto-generated ORDER BY clause: $orderByColumn")
-    props + ("order_by" -> orderByColumn)
+    if (missingColumns.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"ORDER BY column(s) not found in schema: ${missingColumns.mkString(", ")}. " +
+          s"Available columns: ${schema.fields.map(_.name).mkString(", ")}"
+      )
+    }
+
+    ensureNullableKeySupport(schema, props)
   }
 
   private def ensureNullableKeySupport(schema: StructType, props: Map[String, String]): Map[String, String] = {

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTableProvider.scala
@@ -204,8 +204,8 @@ class ClickHouseTableProvider extends TableProvider
       Constants.CATALOG_PROP_USER -> optionsMap.getOrElse("user", "default"),
       Constants.CATALOG_PROP_PASSWORD -> optionsMap.getOrElse("password", "")
     ) ++ (
-      if (optionsMap.contains("timezone")) {
-        Map(Constants.CATALOG_PROP_TZ -> optionsMap("timezone"))
+      if (optionsMap.contains(Constants.CATALOG_PROP_TZ)) {
+        Map(Constants.CATALOG_PROP_TZ -> optionsMap(Constants.CATALOG_PROP_TZ))
       } else {
         Map.empty[String, String]
       }

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/ClickHouseWrite.scala
@@ -49,14 +49,6 @@ class ClickHouseWriteBuilder(writeJob: WriteJobDescription)
       case _: AlwaysTrue => true
       case _ => false
     }
-
-    if (hasPartitionFilters) {
-      log.warn(
-        s"Conditional overwrite with partition filters is not fully supported, filters: ${filters.mkString(", ")}"
-      )
-    } else {
-      log.info("Full table overwrite (no partition filters)")
-    }
     this
   }
 }
@@ -114,11 +106,9 @@ class ClickHouseBatchWrite(
       writeJob.tableEngineSpec match {
         case DistributedEngineSpec(_, cluster, local_db, local_table, _, _) =>
           val sql = s"TRUNCATE TABLE IF EXISTS `$local_db`.`$local_table` ON CLUSTER `$cluster`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
         case _ =>
           val sql = s"TRUNCATE TABLE IF EXISTS `${writeJob.targetDatabase(false)}`.`${writeJob.targetTable(false)}`"
-          log.info(s"Executing: $sql")
           nodeClient.syncQueryAndCheckOutputJSONEachRow(sql)
       }
     }

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/write/WriteJobDescription.scala
@@ -63,24 +63,43 @@ case class WriteJobDescription(
     case _ => None
   }
 
-  def sparkSplits: Array[Transform] =
-    if (writeOptions.repartitionByPartition) {
-      ExprUtils.toSparkSplits(
-        shardingKeyIgnoreRand,
-        partitionKey,
-        functionRegistry
-      )
+  // For SharedMergeTree, filter out unsupported partition expressions while keeping supported ones.
+  private lazy val isSharedMergeTree: Boolean =
+    tableEngineSpec.engine_clause.toLowerCase.contains("sharedmergetree")
+
+  private def filterSupportedPartitionExprs(exprs: Option[List[Expr]]): Option[List[Expr]] = {
+    if (!isSharedMergeTree) return exprs
+    exprs.map(_.flatMap { expr =>
+      ExprUtils.toSparkTransformOpt(expr, functionRegistry).map(_ => expr)
+    })
+  }
+
+  def sparkSplits: Array[Transform] = {
+    val _partitionKey = if (writeOptions.repartitionByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
     } else {
-      ExprUtils.toSparkSplits(
-        shardingKeyIgnoreRand,
-        None,
-        functionRegistry
-      )
+      None
     }
+    ExprUtils.toSparkSplits(
+      shardingKeyIgnoreRand,
+      _partitionKey,
+      functionRegistry
+    )
+  }
 
   def sparkSortOrders: Array[SortOrder] = {
-    val _partitionKey = if (writeOptions.localSortByPartition) partitionKey else None
+    val _partitionKey = if (writeOptions.localSortByPartition) {
+      filterSupportedPartitionExprs(partitionKey)
+    } else {
+      None
+    }
     val _sortingKey = if (writeOptions.localSortByKey) sortingKey else None
-    ExprUtils.toSparkSortOrders(shardingKeyIgnoreRand, _partitionKey, _sortingKey, cluster, functionRegistry)
+    ExprUtils.toSparkSortOrders(
+      shardingKeyIgnoreRand,
+      _partitionKey,
+      _sortingKey,
+      cluster,
+      functionRegistry
+    )
   }
 }

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -173,9 +173,9 @@ object ExprUtils extends SQLConfHelper with Serializable {
       case Success(t: Transform) => Some(t)
       case Success(_) => None
       case Failure(_) if conf.getConf(IGNORE_UNSUPPORTED_TRANSFORM) => None
-      case Failure(rethrow) => throw new AnalysisException(
-          errorClass = "UNSUPPORTED_FEATURE.TRANSFORM_EXPRESSION",
-          messageParameters = Map("transform" -> rethrow.getMessage),
+      case Failure(rethrow) =>
+        throw CHClientException(
+          s"Unsupported transform expression: ${rethrow.getMessage}",
           cause = Some(rethrow)
         )
     }


### PR DESCRIPTION
## Add TableProvider for Format-Based API Access #470 

Implements `ClickHouseTableProvider` to enable `.format("clickhouse")` syntax, essential for **Databricks Unity Catalog** environments where custom catalogs cannot be registered.

### Features

#### Core Functionality
- **Format name**: `"clickhouse"` - standard Spark DataSource V2 format registration
- **Predicate pushdown** & **column pruning** - verified via `system.query_log` inspection
- **Auto schema inference** - reads table schema from ClickHouse with ORDER BY generation
- **Nullable key support** - automatic `allow_nullable_key` setting for partition/sorting keys

#### Write Modes
- `SaveMode.Append` - append data to existing table
- `SaveMode.Overwrite` - truncate table before writing (full table overwrite) 

#### Overwrite Implementation
- Implements `SupportsOverwrite` trait in `ClickHouseWriteBuilder`  #33 
- Executes `TRUNCATE TABLE` before writing in overwrite mode
- Optimized distributed table handling with single `ON CLUSTER` command
- **Note**: Dynamic partition overwrite not yet implemented - currently only full table truncate

#### ClickHouse Cloud Compatibility
- **SharedMergeTree support** - added `SharedMergeTree` engine parsing in `AstVisitor`
- **Partition expression filtering** - filters unsupported Spark transformations (e.g., `xxHash64` in Spark 3.3) for SharedMergeTree tables
- **Graceful degradation** - keeps supported partition expressions while filtering incompatible ones
- Maintains Spark-side partitioning benefits while avoiding `AnalysisException` errors
- Applied across all Spark versions (3.3, 3.4, 3.5, 4.0)

### Usage

```scala
// Read with format API
val df = spark.read.format("clickhouse")
  .option("host", "localhost")
  .option("database", "default")
  .option("table", "my_table")
  .load()

// Write with overwrite mode
df.write.format("clickhouse")
  .mode(SaveMode.Overwrite)
  .option("host", "localhost")
  .option("database", "default")
  .option("table", "my_table")
  .save()

// Catalog API still available
spark.table("clickhouse.default.my_table")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables format-based access via DataSource V2 for ClickHouse with improved write semantics and engine compatibility.
> 
> - Adds `ClickHouseTableProvider` (format name: `"clickhouse"`) with schema inference, predicate pushdown, and column pruning; registers via `META-INF/services/...DataSourceRegister`
> - Implements overwrite by adding `SupportsOverwrite` to `ClickHouseWrite` and truncating target tables (incl. `ON CLUSTER` for distributed) before write
> - Extends table capabilities with `OVERWRITE_BY_FILTER` and adds SharedMergeTree parsing in `AstVisitor`
> - Filters unsupported partition expressions for `SharedMergeTree` in `WriteJobDescription` to avoid analysis errors
> - Updates/extends IT tests: new `ClickHouseTableProviderSuite`; reader tests compare Catalog vs TableProvider paths; helper API updated to pass `(db, tbl)`
> - Build/doc updates: new `SPARK_VERSION_DIFFERENCES.md`; service files added; Gradle tweaks (mirror repo, ASM 9.6)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b162bf21e1f79ea35d3da54ae165e1f705f328f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->