### PR TITLE
fix: Move useNullableQuerySchema override from ClickHouseTable to ClickHouseCatalog

### DIFF
--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -95,9 +95,6 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
-
-  // for SPARK-43390
-  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -16,7 +16,7 @@ package com.clickhouse.spark
 
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog._
@@ -96,9 +96,6 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
-
-  // for SPARK-43390
-  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -54,8 +54,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
-        // TODO nested field does not respect nullable
-        // assert(StructType(schema) === tblSchema)
+        assert(StructType(schema) === tblSchema)
       } else {
         val nullableFields =
           schema.fields.map(structField => structField.copy(dataType = structField.dataType.asNullable))

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -54,7 +54,18 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
-        assert(StructType(schema) === tblSchema)
+        // SPARK-43390 preserves top-level field nullability (all should be false here).
+        // However, Spark SQL DDL does not preserve containsNull for ArrayType and
+        // valueContainsNull for MapType, so these are normalized to true when
+        // the table is created through Spark SQL.
+        val expectedFields = schema.fields.map { f =>
+          f.copy(dataType = f.dataType match {
+            case ArrayType(et, _) => ArrayType(et, containsNull = true)
+            case MapType(kt, vt, _) => MapType(kt, vt, valueContainsNull = true)
+            case other => other
+          })
+        }
+        assert(StructType(expectedFields) === tblSchema)
       } else {
         val nullableFields =
           schema.fields.map(structField => structField.copy(dataType = structField.dataType.asNullable))

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -17,7 +17,9 @@ package com.clickhouse.spark
 import com.clickhouse.client.ClickHouseProtocol
 import com.clickhouse.spark.exception.CHClientException
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.clickhouse.{ExprUtils, SchemaUtils}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.USE_NULLABLE_QUERY_SCHEMA
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.connector.expressions.Transform
@@ -46,6 +48,7 @@ class ClickHouseCatalog extends TableCatalog
     with FunctionCatalog
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   private var catalogName: String = _
@@ -105,6 +108,9 @@ class ClickHouseCatalog extends TableCatalog
   }
 
   override def name(): String = catalogName
+
+  // for SPARK-43390
+  override def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   @throws[NoSuchNamespaceException]
   override def listTables(namespace: Array[String]): Array[Identifier] = namespace match {

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -19,7 +19,7 @@ import com.clickhouse.spark.expr.{Expr, OrderExpr}
 import com.clickhouse.spark.func.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog._
@@ -106,9 +106,6 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
-
-  // for SPARK-43390
-  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -54,8 +54,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
-        // TODO nested field does not respect nullable
-        // assert(StructType(schema) === tblSchema)
+        assert(StructType(schema) === tblSchema)
       } else {
         val nullableFields =
           schema.fields.map(structField => structField.copy(dataType = structField.dataType.asNullable))

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -54,7 +54,18 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
-        assert(StructType(schema) === tblSchema)
+        // SPARK-43390 preserves top-level field nullability (all should be false here).
+        // However, Spark SQL DDL does not preserve containsNull for ArrayType and
+        // valueContainsNull for MapType, so these are normalized to true when
+        // the table is created through Spark SQL.
+        val expectedFields = schema.fields.map { f =>
+          f.copy(dataType = f.dataType match {
+            case ArrayType(et, _) => ArrayType(et, containsNull = true)
+            case MapType(kt, vt, _) => MapType(kt, vt, valueContainsNull = true)
+            case other => other
+          })
+        }
+        assert(StructType(expectedFields) === tblSchema)
       } else {
         val nullableFields =
           schema.fields.map(structField => structField.copy(dataType = structField.dataType.asNullable))

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -17,7 +17,9 @@ package com.clickhouse.spark
 import com.clickhouse.client.ClickHouseProtocol
 import com.clickhouse.spark.exception.CHClientException
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.clickhouse.{ExprUtils, SchemaUtils}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.USE_NULLABLE_QUERY_SCHEMA
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 import org.apache.spark.sql.connector.expressions.Transform
@@ -46,6 +48,7 @@ class ClickHouseCatalog extends TableCatalog
     with FunctionCatalog
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   private var catalogName: String = _
@@ -105,6 +108,9 @@ class ClickHouseCatalog extends TableCatalog
   }
 
   override def name(): String = catalogName
+
+  // for SPARK-43390
+  override def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   @throws[NoSuchNamespaceException]
   override def listTables(namespace: Array[String]): Array[Identifier] = namespace match {

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -19,7 +19,7 @@ import com.clickhouse.spark.expr.{Expr, OrderExpr}
 import com.clickhouse.spark.func.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
-import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.{READ_DISTRIBUTED_CONVERT_LOCAL, USE_NULLABLE_QUERY_SCHEMA}
+import org.apache.spark.sql.clickhouse.ClickHouseSQLConf.READ_DISTRIBUTED_CONVERT_LOCAL
 import org.apache.spark.sql.clickhouse.{ExprUtils, ReadOptions, WriteOptions}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog._
@@ -106,9 +106,6 @@ case class ClickHouseTable(
   }
 
   override def name: String = s"${wrapBackQuote(spec.database)}.${wrapBackQuote(spec.name)}"
-
-  // for SPARK-43390
-  def useNullableQuerySchema: Boolean = conf.getConf(USE_NULLABLE_QUERY_SCHEMA)
 
   override def capabilities(): util.Set[TableCapability] =
     Set(


### PR DESCRIPTION
## Summary
Fixes [https://github.com/ClickHouse/spark-clickhouse-connector/issues/382](vscode-file://vscode-app/snap/code/219/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

The `useNullableQuerySchema` method was incorrectly placed in `ClickHouseTable` instead of `ClickHouseCatalog`. The method was introduced to support [SPARK-43390](vscode-file://vscode-app/snap/code/219/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which added `useNullableQuerySchema` to the `org.apache.spark.sql.connector.catalog.TableCatalog` interface. Since `ClickHouseTable` does not implement `TableCatalog`, the override had no effect — the method was never called by the Spark engine.

This PR moves the override to `ClickHouseCatalog`, which is the actual `TableCatalog` implementation, ensuring Spark properly picks up the configured value from `spark.clickhouse.read.useNullableQuerySchema`.

## Changes

**Spark 3.5 and Spark 4.0** (where `TableCatalog.useNullableQuerySchema` exists):

**`ClickHouseCatalog.scala`**: Added `SQLConfHelper` mixin and `override def useNullableQuerySchem`a that reads from `USE_NULLABLE_QUERY_SCHEMA` configuration.
**`ClickHouseTable.scala`**: Removed the dead `useNullableQuerySchema` method and unused `USE_NULLABLE_QUERY_SCHEMA` import.

**Spark 3.3 and Spark 3.4** (where `TableCatalog` does not have this method):

**`ClickHouseTable.scala`**: Removed the dead `useNullableQuerySchema` method and unused `USE_NULLABLE_QUERY_SCHEMA` import, since `TableCatalog` in these Spark versions does not define this method.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to a Spark catalog override and related tests; primary risk is behavioral change in schema nullability for `CREATE/REPLACE TABLE ... AS SELECT` on Spark 3.5+/4.0 when the config is set.
> 
> **Overview**
> Fixes SPARK-43390 nullable-schema handling by **moving the `useNullableQuerySchema` override to `ClickHouseCatalog` (Spark 3.5/4.0)**, so Spark reads `spark.clickhouse.useNullableQuerySchema` from the actual `TableCatalog`.
> 
> Removes the now-dead `useNullableQuerySchema` method and related `USE_NULLABLE_QUERY_SCHEMA` imports from `ClickHouseTable` across Spark 3.3–4.0, and updates Spark 3.5/4.0 integration tests to assert nested nullability is respected when the config disables nullable query schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ecdc5136c8f43ba0d481bc468bdd021511324d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->