### PR TITLE
Bump testcontainers-scala 0.44.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -61,6 +61,6 @@ commons_codec_version=1.17.2
 
 # Test only
 kyuubi_version=1.10.2
-testcontainers_scala_version=0.41.2
+testcontainers_scala_version=0.44.1
 scalatest_version=3.2.19
 flexmark_version=0.62.2


### PR DESCRIPTION
## Summary

Bump testcontainers-scala 0.44.1, to fix the issue "Docker 29.0.0 could not find a valid Docker environment"

https://github.com/testcontainers/testcontainers-java/issues/11212

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple dependency version bump limited to test infrastructure; low likelihood of impacting production code.
> 
> **Overview**
> Updates the test-only dependency `testcontainers-scala` from `0.41.2` to `0.44.1` via `gradle.properties`, to improve compatibility with newer Docker environments during integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd4ff3a7b90a30d1b826f0d881433169d2743fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->