### PR TITLE
Set DOCKER_MIN_API_VERSION=1.24 in GHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
             java: 8
     env:
       CLICKHOUSE_IMAGE: clickhouse/clickhouse-server:${{ matrix.clickhouse }}
+      DOCKER_MIN_API_VERSION: "1.24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -56,6 +56,7 @@ jobs:
     env:
       CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
       CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+      DOCKER_MIN_API_VERSION: "1.24"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -23,6 +23,8 @@ jobs:
   sonar-report:
     if: ${{ startsWith(github.repository, 'clickhouse/') }}
     runs-on: ubuntu-22.04
+    env:
+      DOCKER_MIN_API_VERSION: "1.24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -40,6 +40,8 @@ jobs:
           # Spark 4.0 requires Java 17+
           - spark: '4.0'
             java: 8
+    env:
+      DOCKER_MIN_API_VERSION: "1.24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Workaround https://github.com/testcontainers/testcontainers-java/issues/11212

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only environment variable changes; low blast radius and no production/runtime code impact.
> 
> **Overview**
> Sets `DOCKER_MIN_API_VERSION` to `1.24` in GitHub Actions workflows (`build-and-test`, `cloud`, `tpcds`, and `sonar`) so CI uses a consistent minimum Docker API version when running tests/analysis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac701479ca5eef530bc1ffa3b249340186bddeca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->