### PR TITLE
fix: ensure test helper functions execute test bodies

### DIFF
--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -51,7 +51,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
     val db = "t_w_s_db"
     val tbl = "t_w_s_tbl"
     withTable(db, tbl, schema) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
         assert(StructType(schema) === tblSchema)
@@ -67,11 +67,11 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       )).toDF("id", "col_string", "col_date", "col_array_string", "col_map_string_string")
 
       spark.createDataFrame(dataDF.rdd, tblSchema)
-        .writeTo(s"$db.$tbl")
+        .writeTo(s"$actualDb.$actualTbl")
         .append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("id"),
+        spark.table(s"$actualDb.$actualTbl").sort("id"),
         Row(1L, "a", date("1996-06-06"), Seq("a", "b", "c"), Map("a" -> "x")) ::
           Row(2L, "A", date("2022-04-12"), Seq("A", "B", "C"), Map("A" -> "X")) :: Nil
       )
@@ -188,8 +188,8 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       Thread.sleep(1000)
     }
     withKVTable(db, tbl, valueColDef = valueColDef) { (actualDb: String, actualTbl: String) =>
-      prepare(db, tbl)
-      val df = spark.sql(s"SELECT key, value FROM $db.$tbl ORDER BY key")
+      prepare(actualDb, actualTbl)
+      val df = spark.sql(s"SELECT key, value FROM $actualDb.$actualTbl ORDER BY key")
       validate(df)
     }
   }

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,7 +122,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) {
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -167,7 +167,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -212,7 +212,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -292,7 +292,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) {
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,9 +122,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11"),
            |  (12L, "2022-04-12") AS tab(id, date)
@@ -135,10 +135,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, date("2022-04-22"))
       ))
         .toDF("id", "date")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11")) ::
           Row(12L, date("2022-04-12")) ::
           Row(21L, date("2022-04-21")) ::
@@ -146,7 +146,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("date=2022-04-11"),
           Row("date=2022-04-12"),
@@ -167,9 +167,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, part_1, part_2)
@@ -181,10 +181,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::
@@ -192,7 +192,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=1/part_2=1"),
           Row("part_1=1/part_2=2"),
@@ -212,9 +212,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11", 1),
            |  (12L, "2022-04-12", 2) AS tab(id, part_1, part_2)
@@ -224,10 +224,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (21L, "2022-04-21", 1),
         (22L, "2022-04-22", 2)
       )).toDF("id", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11"), 1) ::
           Row(12L, date("2022-04-12"), 2) ::
           Row(21L, date("2022-04-21"), 1) ::
@@ -235,7 +235,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=2022-04-11/part_2=1"),
           Row("part_1=2022-04-12/part_2=2"),
@@ -292,9 +292,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, sort_2, sort_3)
@@ -306,10 +306,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "sort_2", "sort_3")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -1429,12 +1429,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   }
 
   test("decode StructType - unnamed tuple created directly in ClickHouse") {
-    val db = "test_db"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "test_db"
     val tbl = "test_read_unnamed_tuple"
 
     try {
-      // Create database
-      runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      // Create database only if not using suite level database
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      }
 
       // Create table directly in ClickHouse with unnamed tuple
       runClickHouseSQL(
@@ -1484,8 +1486,12 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(data2.getInt(1) === 35)
       assert(data2.getString(2) === "SF")
 
-    } finally
-      runClickHouseSQL(s"DROP TABLE IF EXISTS $db.$tbl")
+    } finally {
+      dropTableWithRetry(db, tbl)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
+      }
+    }
   }
 
 }

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -255,7 +255,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       }
     }
   }
-  test("decode BooleanType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode BooleanType - nullable with null values") {
     withKVTable("test_db", "test_bool_null", valueColDef = "Nullable(Bool)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_bool_null VALUES
@@ -304,7 +304,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ByteType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ByteType - nullable with null values") {
     withKVTable("test_db", "test_byte_null", valueColDef = "Nullable(Int8)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_byte_null VALUES
@@ -337,7 +337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getTimestamp(1) != null)
     }
   }
-  test("decode DateTime32 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateTime32 - nullable with null values") {
     withKVTable("test_db", "test_datetime32_null", valueColDef = "Nullable(DateTime32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -374,7 +374,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32") {
     withKVTable("test_db", "test_date32", valueColDef = "Date32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_date32 VALUES
@@ -392,7 +392,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32 nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32 nullable with null values") {
     withKVTable("test_db", "test_date32_null", valueColDef = "Nullable(Date32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -582,7 +582,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getDouble(1) - 3.141592653589793) < 0.000001)
     }
   }
-  test("decode Enum16 - large enum") { (actualDb: String, actualTbl: String) =>
+  test("decode Enum16 - large enum") {
     withKVTable("test_db", "test_enum16", valueColDef = "Enum16('small' = 1, 'medium' = 100, 'large' = 1000)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -698,7 +698,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getFloat(1) - 3.14f) < 0.01f)
     }
   }
-  test("decode Int128 - large integers as Decimal") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - large integers as Decimal") {
     withKVTable("test_db", "test_int128", valueColDef = "Int128") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int128 VALUES
@@ -716,7 +716,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDecimal(1) != null)
     }
   }
-  test("decode Int128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - nullable with null values") {
     withKVTable("test_db", "test_int128_null", valueColDef = "Nullable(Int128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -770,7 +770,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode IntegerType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - min and max values") {
     withKVTable("test_db", "test_int", valueColDef = "Int32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int VALUES
@@ -787,7 +787,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode IntegerType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - nullable with null values") {
     withKVTable("test_db", "test_int_null", valueColDef = "Nullable(Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int_null VALUES
@@ -822,7 +822,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "8.8.8.8")
     }
   }
-  test("decode IPv4 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv4 - nullable with null values") {
     withKVTable("test_db", "test_ipv4_null", valueColDef = "Nullable(IPv4)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv4_null VALUES
@@ -858,7 +858,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) != null)
     }
   }
-  test("decode IPv6 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv6 - nullable with null values") {
     withKVTable("test_db", "test_ipv6_null", valueColDef = "Nullable(IPv6)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv6_null VALUES
@@ -880,11 +880,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
     withKVTable("test_db", "test_json_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
-          """INSERT INTO $actualDb.test_json_null VALUES
-            |(1, '{"name": "Alice", "age": 30}'),
-            |(2, NULL),
-            |(3, '{"name": "Charlie", "age": 35}')
-            |""".stripMargin
+          s"""INSERT INTO $actualDb.test_json_null VALUES
+             |(1, '{"name": "Alice", "age": 30}'),
+             |(2, NULL),
+             |(3, '{"name": "Charlie", "age": 35}')
+             |""".stripMargin
         )
 
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -898,11 +898,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   test("decode JSON - semi-structured data") {
     withKVTable("test_db", "test_json", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
-        """INSERT INTO $actualDb.test_json VALUES
-          |(1, '{"name": "Alice", "age": 30}'),
-          |(2, '{"name": "Bob", "age": 25}'),
-          |(3, '{"name": "Charlie", "age": 35}')
-          |""".stripMargin
+        s"""INSERT INTO $actualDb.test_json VALUES
+           |(1, '{"name": "Alice", "age": 30}'),
+           |(2, '{"name": "Bob", "age": 25}'),
+           |(3, '{"name": "Charlie", "age": 35}')
+           |""".stripMargin
       )
 
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -913,7 +913,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1).contains("Charlie"))
     }
   }
-  test("decode LongType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - min and max values") {
     withKVTable("test_db", "test_long", valueColDef = "Int64") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long VALUES
@@ -930,7 +930,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode LongType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - nullable with null values") {
     withKVTable("test_db", "test_long_null", valueColDef = "Nullable(Int64)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long_null VALUES
@@ -982,7 +982,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode MapType - Map of String to Int") { (actualDb: String, actualTbl: String) =>
+  test("decode MapType - Map of String to Int") {
     withKVTable("test_db", "test_map", valueColDef = "Map(String, Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_map VALUES
@@ -1037,7 +1037,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ShortType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ShortType - nullable with null values") {
     withKVTable("test_db", "test_short_null", valueColDef = "Nullable(Int16)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1090,7 +1090,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode StringType - empty strings") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - empty strings") {
     withKVTable("test_db", "test_empty_string", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_empty_string VALUES
@@ -1108,7 +1108,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "")
     }
   }
-  test("decode StringType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - nullable with null values") {
     withKVTable("test_db", "test_string_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1140,11 +1140,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
-        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$$%^&*()") :: Nil
+        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$%^&*()") :: Nil
       )
     }
   }
-  test("decode StringType - UUID") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID") {
     withKVTable("test_db", "test_uuid", valueColDef = "UUID") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid VALUES
@@ -1160,7 +1160,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getString(1) == "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
     }
   }
-  test("decode StringType - UUID nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID nullable with null values") {
     withKVTable("test_db", "test_uuid_null", valueColDef = "Nullable(UUID)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid_null VALUES
@@ -1193,7 +1193,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(0).getString(1).length == 10000)
     }
   }
-  test("decode TimestampType - DateTime") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime") {
     withKVTable("test_db", "test_datetime", valueColDef = "DateTime") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime VALUES
@@ -1211,7 +1211,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getTimestamp(1) != null)
     }
   }
-  test("decode TimestampType - DateTime64") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime64") {
     withKVTable("test_db", "test_datetime64", valueColDef = "DateTime64(3)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime64 VALUES
@@ -1283,7 +1283,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt128 - nullable with null values") {
     withKVTable("test_db", "test_uint128_null", valueColDef = "Nullable(UInt128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1337,7 +1337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode UInt256 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt256 - nullable with null values") {
     withKVTable("test_db", "test_uint256_null", valueColDef = "Nullable(UInt256)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1372,7 +1372,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt64 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt64 - nullable with null values") {
     withKVTable("test_db", "test_uint64_null", valueColDef = "Nullable(UInt64)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1388,14 +1388,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 5)
-        assert(result(0).getDecimal(1) == BigDecimal(0))
+        assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
         assert(result(1).isNullAt(1))
         // Test value just above Long.MAX_VALUE
-        assert(result(2).getDecimal(1) == BigDecimal("9223372036854775808"))
+        assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775808"))
         // Test large value in the middle range
-        assert(result(3).getDecimal(1) == BigDecimal("15000000000000000000"))
+        assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("15000000000000000000"))
         // Test maximum UInt64 value (2^64 - 1)
-        assert(result(4).getDecimal(1) == BigDecimal("18446744073709551615"))
+        assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
   test("decode UInt64 - unsigned 64-bit integers") {
@@ -1414,20 +1414,20 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 6)
-      assert(result(0).getDecimal(1) == BigDecimal(0))
-      assert(result(1).getDecimal(1) == BigDecimal("1234567890"))
+      assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
+      assert(BigDecimal(result(1).getDecimal(1)) == BigDecimal("1234567890"))
       // Max value that fits in signed Long
-      assert(result(2).getDecimal(1) == BigDecimal("9223372036854775807"))
+      assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775807"))
       // Test value just above Long.MAX_VALUE (proves DecimalType works)
-      assert(result(3).getDecimal(1) == BigDecimal("9223372036854775808"))
+      assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("9223372036854775808"))
       // Test large value in the middle range
-      assert(result(4).getDecimal(1) == BigDecimal("15000000000000000000"))
+      assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("15000000000000000000"))
       // Test maximum UInt64 value (2^64 - 1)
-      assert(result(5).getDecimal(1) == BigDecimal("18446744073709551615"))
+      assert(BigDecimal(result(5).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
 
-  test("decode StructType - unnamed tuple created directly in ClickHouse") { (actualDb: String, actualTbl: String) =>
+  test("decode StructType - unnamed tuple created directly in ClickHouse") {
     val db = "test_db"
     val tbl = "test_read_unnamed_tuple"
 

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -58,6 +58,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       .option("password", clickhousePassword)
       .option("database", db)
       .option("table", tbl)
+      .option("ssl", isSslEnabled.toString)
       .load()
 
     val tableProviderDFSelected = if (columns == "*") {

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -36,7 +36,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   ))
 
   test("write and read using format API") {
-    withTable("format_api_db", "test_format_api", testSchema) {
+    withTable("format_api_db", "test_format_api", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -75,7 +75,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("append mode adds data without replacing existing") {
-    withTable("append_db", "test_append", testSchema) {
+    withTable("append_db", "test_append", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -108,7 +108,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("overwrite mode replaces all existing data") {
-    withTable("overwrite_db", "test_overwrite", testSchema) {
+    withTable("overwrite_db", "test_overwrite", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -198,7 +198,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("predicate pushdown filters data server-side") {
-    withTable("filter_db", "test_filter", testSchema) {
+    withTable("filter_db", "test_filter", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -308,7 +308,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("column pruning reduces data transfer") {
-    withTable("prune_db", "test_prune", testSchema) {
+    withTable("prune_db", "test_prune", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -370,7 +370,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       StructField("value", DoubleType, nullable = true)
     ))
 
-    withTable("null_db", "test_nulls", nullableSchema) {
+    withTable("null_db", "test_nulls", nullableSchema) { (_, _) =>
       val writeData = Seq(
         (1, Some("Alice"), Some(95.5)),
         (2, None, Some(87.3)),
@@ -402,7 +402,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("write empty dataframe") {
-    withTable("empty_db", "test_empty", testSchema) {
+    withTable("empty_db", "test_empty", testSchema) { (_, _) =>
       // Create empty DataFrame with proper schema
       val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
         .toDF("id", "name", "value", "created")

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
@@ -779,7 +779,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_simple_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_simple_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_simple_struct").sort("id").collect()
 
@@ -828,7 +828,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nested_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nested_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nested_struct").sort("id").collect()
 
@@ -867,7 +867,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nullable_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nullable_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nullable_struct").sort("id").collect()
 
@@ -905,7 +905,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_complex_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_complex_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_complex_struct").sort("id").collect()
 
@@ -952,7 +952,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_struct_array").append()
+      dataDF.writeTo(s"$actualDb.test_write_struct_array").append()
 
       val result = spark.table(s"$actualDb.test_write_struct_array").sort("id").collect()
 

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -104,7 +104,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     engine: String = "MergeTree()",
     sortKeys: Seq[String] = "id" :: Nil,
     partKeys: Seq[String] = Seq.empty
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -125,7 +125,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)
@@ -140,7 +140,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     tbl: String,
     keyColDef: String = "Int32",
     valueColDef: String
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -157,7 +157,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -51,7 +51,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
     val db = "t_w_s_db"
     val tbl = "t_w_s_tbl"
     withTable(db, tbl, schema) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
         assert(StructType(schema) === tblSchema)
@@ -67,11 +67,11 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       )).toDF("id", "col_string", "col_date", "col_array_string", "col_map_string_string")
 
       spark.createDataFrame(dataDF.rdd, tblSchema)
-        .writeTo(s"$db.$tbl")
+        .writeTo(s"$actualDb.$actualTbl")
         .append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("id"),
+        spark.table(s"$actualDb.$actualTbl").sort("id"),
         Row(1L, "a", date("1996-06-06"), Seq("a", "b", "c"), Map("a" -> "x")) ::
           Row(2L, "A", date("2022-04-12"), Seq("A", "B", "C"), Map("A" -> "X")) :: Nil
       )

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,7 +122,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) {
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -167,7 +167,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -212,7 +212,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -292,7 +292,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) {
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,9 +122,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11"),
            |  (12L, "2022-04-12") AS tab(id, date)
@@ -135,10 +135,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, date("2022-04-22"))
       ))
         .toDF("id", "date")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11")) ::
           Row(12L, date("2022-04-12")) ::
           Row(21L, date("2022-04-21")) ::
@@ -146,7 +146,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("date=2022-04-11"),
           Row("date=2022-04-12"),
@@ -167,9 +167,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, part_1, part_2)
@@ -181,10 +181,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::
@@ -192,7 +192,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=1/part_2=1"),
           Row("part_1=1/part_2=2"),
@@ -212,9 +212,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11", 1),
            |  (12L, "2022-04-12", 2) AS tab(id, part_1, part_2)
@@ -224,10 +224,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (21L, "2022-04-21", 1),
         (22L, "2022-04-22", 2)
       )).toDF("id", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11"), 1) ::
           Row(12L, date("2022-04-12"), 2) ::
           Row(21L, date("2022-04-21"), 1) ::
@@ -235,7 +235,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=2022-04-11/part_2=1"),
           Row("part_1=2022-04-12/part_2=2"),
@@ -292,9 +292,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, sort_2, sort_3)
@@ -306,10 +306,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "sort_2", "sort_3")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -1429,12 +1429,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   }
 
   test("decode StructType - unnamed tuple created directly in ClickHouse") {
-    val db = "test_db"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "test_db"
     val tbl = "test_read_unnamed_tuple"
 
     try {
-      // Create database
-      runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      // Create database only if not using suite level database
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      }
 
       // Create table directly in ClickHouse with unnamed tuple
       runClickHouseSQL(
@@ -1484,8 +1486,12 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(data2.getInt(1) === 35)
       assert(data2.getString(2) === "SF")
 
-    } finally
-      runClickHouseSQL(s"DROP TABLE IF EXISTS $db.$tbl")
+    } finally {
+      dropTableWithRetry(db, tbl)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
+      }
+    }
   }
 
 }

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -255,7 +255,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       }
     }
   }
-  test("decode BooleanType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode BooleanType - nullable with null values") {
     withKVTable("test_db", "test_bool_null", valueColDef = "Nullable(Bool)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_bool_null VALUES
@@ -304,7 +304,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ByteType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ByteType - nullable with null values") {
     withKVTable("test_db", "test_byte_null", valueColDef = "Nullable(Int8)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_byte_null VALUES
@@ -337,7 +337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getTimestamp(1) != null)
     }
   }
-  test("decode DateTime32 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateTime32 - nullable with null values") {
     withKVTable("test_db", "test_datetime32_null", valueColDef = "Nullable(DateTime32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -374,7 +374,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32") {
     withKVTable("test_db", "test_date32", valueColDef = "Date32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_date32 VALUES
@@ -392,7 +392,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32 nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32 nullable with null values") {
     withKVTable("test_db", "test_date32_null", valueColDef = "Nullable(Date32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -582,7 +582,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getDouble(1) - 3.141592653589793) < 0.000001)
     }
   }
-  test("decode Enum16 - large enum") { (actualDb: String, actualTbl: String) =>
+  test("decode Enum16 - large enum") {
     withKVTable("test_db", "test_enum16", valueColDef = "Enum16('small' = 1, 'medium' = 100, 'large' = 1000)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -698,7 +698,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getFloat(1) - 3.14f) < 0.01f)
     }
   }
-  test("decode Int128 - large integers as Decimal") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - large integers as Decimal") {
     withKVTable("test_db", "test_int128", valueColDef = "Int128") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int128 VALUES
@@ -716,7 +716,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDecimal(1) != null)
     }
   }
-  test("decode Int128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - nullable with null values") {
     withKVTable("test_db", "test_int128_null", valueColDef = "Nullable(Int128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -770,7 +770,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode IntegerType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - min and max values") {
     withKVTable("test_db", "test_int", valueColDef = "Int32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int VALUES
@@ -787,7 +787,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode IntegerType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - nullable with null values") {
     withKVTable("test_db", "test_int_null", valueColDef = "Nullable(Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int_null VALUES
@@ -822,7 +822,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "8.8.8.8")
     }
   }
-  test("decode IPv4 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv4 - nullable with null values") {
     withKVTable("test_db", "test_ipv4_null", valueColDef = "Nullable(IPv4)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv4_null VALUES
@@ -858,7 +858,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) != null)
     }
   }
-  test("decode IPv6 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv6 - nullable with null values") {
     withKVTable("test_db", "test_ipv6_null", valueColDef = "Nullable(IPv6)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv6_null VALUES
@@ -880,11 +880,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
     withKVTable("test_db", "test_json_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
-          """INSERT INTO $actualDb.test_json_null VALUES
-            |(1, '{"name": "Alice", "age": 30}'),
-            |(2, NULL),
-            |(3, '{"name": "Charlie", "age": 35}')
-            |""".stripMargin
+          s"""INSERT INTO $actualDb.test_json_null VALUES
+             |(1, '{"name": "Alice", "age": 30}'),
+             |(2, NULL),
+             |(3, '{"name": "Charlie", "age": 35}')
+             |""".stripMargin
         )
 
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -898,11 +898,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   test("decode JSON - semi-structured data") {
     withKVTable("test_db", "test_json", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
-        """INSERT INTO $actualDb.test_json VALUES
-          |(1, '{"name": "Alice", "age": 30}'),
-          |(2, '{"name": "Bob", "age": 25}'),
-          |(3, '{"name": "Charlie", "age": 35}')
-          |""".stripMargin
+        s"""INSERT INTO $actualDb.test_json VALUES
+           |(1, '{"name": "Alice", "age": 30}'),
+           |(2, '{"name": "Bob", "age": 25}'),
+           |(3, '{"name": "Charlie", "age": 35}')
+           |""".stripMargin
       )
 
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -913,7 +913,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1).contains("Charlie"))
     }
   }
-  test("decode LongType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - min and max values") {
     withKVTable("test_db", "test_long", valueColDef = "Int64") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long VALUES
@@ -930,7 +930,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode LongType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - nullable with null values") {
     withKVTable("test_db", "test_long_null", valueColDef = "Nullable(Int64)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long_null VALUES
@@ -982,7 +982,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode MapType - Map of String to Int") { (actualDb: String, actualTbl: String) =>
+  test("decode MapType - Map of String to Int") {
     withKVTable("test_db", "test_map", valueColDef = "Map(String, Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_map VALUES
@@ -1037,7 +1037,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ShortType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ShortType - nullable with null values") {
     withKVTable("test_db", "test_short_null", valueColDef = "Nullable(Int16)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1090,7 +1090,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode StringType - empty strings") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - empty strings") {
     withKVTable("test_db", "test_empty_string", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_empty_string VALUES
@@ -1108,7 +1108,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "")
     }
   }
-  test("decode StringType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - nullable with null values") {
     withKVTable("test_db", "test_string_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1140,11 +1140,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
-        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$$%^&*()") :: Nil
+        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$%^&*()") :: Nil
       )
     }
   }
-  test("decode StringType - UUID") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID") {
     withKVTable("test_db", "test_uuid", valueColDef = "UUID") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid VALUES
@@ -1160,7 +1160,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getString(1) == "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
     }
   }
-  test("decode StringType - UUID nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID nullable with null values") {
     withKVTable("test_db", "test_uuid_null", valueColDef = "Nullable(UUID)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid_null VALUES
@@ -1193,7 +1193,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(0).getString(1).length == 10000)
     }
   }
-  test("decode TimestampType - DateTime") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime") {
     withKVTable("test_db", "test_datetime", valueColDef = "DateTime") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime VALUES
@@ -1211,7 +1211,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getTimestamp(1) != null)
     }
   }
-  test("decode TimestampType - DateTime64") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime64") {
     withKVTable("test_db", "test_datetime64", valueColDef = "DateTime64(3)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime64 VALUES
@@ -1283,7 +1283,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt128 - nullable with null values") {
     withKVTable("test_db", "test_uint128_null", valueColDef = "Nullable(UInt128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1337,7 +1337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode UInt256 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt256 - nullable with null values") {
     withKVTable("test_db", "test_uint256_null", valueColDef = "Nullable(UInt256)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1372,7 +1372,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt64 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt64 - nullable with null values") {
     withKVTable("test_db", "test_uint64_null", valueColDef = "Nullable(UInt64)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1388,14 +1388,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 5)
-        assert(result(0).getDecimal(1) == BigDecimal(0))
+        assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
         assert(result(1).isNullAt(1))
         // Test value just above Long.MAX_VALUE
-        assert(result(2).getDecimal(1) == BigDecimal("9223372036854775808"))
+        assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775808"))
         // Test large value in the middle range
-        assert(result(3).getDecimal(1) == BigDecimal("15000000000000000000"))
+        assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("15000000000000000000"))
         // Test maximum UInt64 value (2^64 - 1)
-        assert(result(4).getDecimal(1) == BigDecimal("18446744073709551615"))
+        assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
   test("decode UInt64 - unsigned 64-bit integers") {
@@ -1414,20 +1414,20 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 6)
-      assert(result(0).getDecimal(1) == BigDecimal(0))
-      assert(result(1).getDecimal(1) == BigDecimal("1234567890"))
+      assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
+      assert(BigDecimal(result(1).getDecimal(1)) == BigDecimal("1234567890"))
       // Max value that fits in signed Long
-      assert(result(2).getDecimal(1) == BigDecimal("9223372036854775807"))
+      assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775807"))
       // Test value just above Long.MAX_VALUE (proves DecimalType works)
-      assert(result(3).getDecimal(1) == BigDecimal("9223372036854775808"))
+      assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("9223372036854775808"))
       // Test large value in the middle range
-      assert(result(4).getDecimal(1) == BigDecimal("15000000000000000000"))
+      assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("15000000000000000000"))
       // Test maximum UInt64 value (2^64 - 1)
-      assert(result(5).getDecimal(1) == BigDecimal("18446744073709551615"))
+      assert(BigDecimal(result(5).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
 
-  test("decode StructType - unnamed tuple created directly in ClickHouse") { (actualDb: String, actualTbl: String) =>
+  test("decode StructType - unnamed tuple created directly in ClickHouse") {
     val db = "test_db"
     val tbl = "test_read_unnamed_tuple"
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -58,6 +58,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       .option("password", clickhousePassword)
       .option("database", db)
       .option("table", tbl)
+      .option("ssl", isSslEnabled.toString)
       .load()
 
     val tableProviderDFSelected = if (columns == "*") {

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -36,7 +36,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   ))
 
   test("write and read using format API") {
-    withTable("format_api_db", "test_format_api", testSchema) {
+    withTable("format_api_db", "test_format_api", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -75,7 +75,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("append mode adds data without replacing existing") {
-    withTable("append_db", "test_append", testSchema) {
+    withTable("append_db", "test_append", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -108,7 +108,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("overwrite mode replaces all existing data") {
-    withTable("overwrite_db", "test_overwrite", testSchema) {
+    withTable("overwrite_db", "test_overwrite", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -198,7 +198,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("predicate pushdown filters data server-side") {
-    withTable("filter_db", "test_filter", testSchema) {
+    withTable("filter_db", "test_filter", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -308,7 +308,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("column pruning reduces data transfer") {
-    withTable("prune_db", "test_prune", testSchema) {
+    withTable("prune_db", "test_prune", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -370,7 +370,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       StructField("value", DoubleType, nullable = true)
     ))
 
-    withTable("null_db", "test_nulls", nullableSchema) {
+    withTable("null_db", "test_nulls", nullableSchema) { (_, _) =>
       val writeData = Seq(
         (1, Some("Alice"), Some(95.5)),
         (2, None, Some(87.3)),
@@ -402,7 +402,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("write empty dataframe") {
-    withTable("empty_db", "test_empty", testSchema) {
+    withTable("empty_db", "test_empty", testSchema) { (_, _) =>
       // Create empty DataFrame with proper schema
       val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
         .toDF("id", "name", "value", "created")

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
@@ -779,7 +779,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_simple_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_simple_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_simple_struct").sort("id").collect()
 
@@ -828,7 +828,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nested_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nested_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nested_struct").sort("id").collect()
 
@@ -867,7 +867,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nullable_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nullable_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nullable_struct").sort("id").collect()
 
@@ -905,7 +905,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_complex_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_complex_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_complex_struct").sort("id").collect()
 
@@ -952,7 +952,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_struct_array").append()
+      dataDF.writeTo(s"$actualDb.test_write_struct_array").append()
 
       val result = spark.table(s"$actualDb.test_write_struct_array").sort("id").collect()
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -103,7 +103,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     engine: String = "MergeTree()",
     sortKeys: Seq[String] = "id" :: Nil,
     partKeys: Seq[String] = Seq.empty
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -124,7 +124,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)
@@ -139,7 +139,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     tbl: String,
     keyColDef: String = "Int32",
     valueColDef: String
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -156,7 +156,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -51,7 +51,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
     val db = "t_w_s_db"
     val tbl = "t_w_s_tbl"
     withTable(db, tbl, schema) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
         // TODO nested field does not respect nullable
@@ -68,11 +68,11 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       )).toDF("id", "col_string", "col_date", "col_array_string", "col_map_string_string")
 
       spark.createDataFrame(dataDF.rdd, tblSchema)
-        .writeTo(s"$db.$tbl")
+        .writeTo(s"$actualDb.$actualTbl")
         .append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("id"),
+        spark.table(s"$actualDb.$actualTbl").sort("id"),
         Row(1L, "a", date("1996-06-06"), Seq("a", "b", "c"), Map("a" -> "x")) ::
           Row(2L, "A", date("2022-04-12"), Seq("A", "B", "C"), Map("A" -> "X")) :: Nil
       )

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,7 +122,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) {
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -167,7 +167,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -212,7 +212,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -292,7 +292,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) {
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,9 +122,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11"),
            |  (12L, "2022-04-12") AS tab(id, date)
@@ -135,10 +135,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, date("2022-04-22"))
       ))
         .toDF("id", "date")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11")) ::
           Row(12L, date("2022-04-12")) ::
           Row(21L, date("2022-04-21")) ::
@@ -146,7 +146,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("date=2022-04-11"),
           Row("date=2022-04-12"),
@@ -167,9 +167,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, part_1, part_2)
@@ -181,10 +181,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::
@@ -192,7 +192,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=1/part_2=1"),
           Row("part_1=1/part_2=2"),
@@ -212,9 +212,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11", 1),
            |  (12L, "2022-04-12", 2) AS tab(id, part_1, part_2)
@@ -224,10 +224,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (21L, "2022-04-21", 1),
         (22L, "2022-04-22", 2)
       )).toDF("id", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11"), 1) ::
           Row(12L, date("2022-04-12"), 2) ::
           Row(21L, date("2022-04-21"), 1) ::
@@ -235,7 +235,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=2022-04-11/part_2=1"),
           Row("part_1=2022-04-12/part_2=2"),
@@ -292,9 +292,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, sort_2, sort_3)
@@ -306,10 +306,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "sort_2", "sort_3")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -1429,12 +1429,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   }
 
   test("decode StructType - unnamed tuple created directly in ClickHouse") {
-    val db = "test_db"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "test_db"
     val tbl = "test_read_unnamed_tuple"
 
     try {
-      // Create database
-      runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      // Create database only if not using suite level database
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      }
 
       // Create table directly in ClickHouse with unnamed tuple
       runClickHouseSQL(
@@ -1484,8 +1486,12 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(data2.getInt(1) === 35)
       assert(data2.getString(2) === "SF")
 
-    } finally
-      runClickHouseSQL(s"DROP TABLE IF EXISTS $db.$tbl")
+    } finally {
+      dropTableWithRetry(db, tbl)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
+      }
+    }
   }
 
 }

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -255,7 +255,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       }
     }
   }
-  test("decode BooleanType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode BooleanType - nullable with null values") {
     withKVTable("test_db", "test_bool_null", valueColDef = "Nullable(Bool)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_bool_null VALUES
@@ -304,7 +304,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ByteType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ByteType - nullable with null values") {
     withKVTable("test_db", "test_byte_null", valueColDef = "Nullable(Int8)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_byte_null VALUES
@@ -337,7 +337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getTimestamp(1) != null)
     }
   }
-  test("decode DateTime32 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateTime32 - nullable with null values") {
     withKVTable("test_db", "test_datetime32_null", valueColDef = "Nullable(DateTime32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -374,7 +374,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32") {
     withKVTable("test_db", "test_date32", valueColDef = "Date32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_date32 VALUES
@@ -392,7 +392,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32 nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32 nullable with null values") {
     withKVTable("test_db", "test_date32_null", valueColDef = "Nullable(Date32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -582,7 +582,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getDouble(1) - 3.141592653589793) < 0.000001)
     }
   }
-  test("decode Enum16 - large enum") { (actualDb: String, actualTbl: String) =>
+  test("decode Enum16 - large enum") {
     withKVTable("test_db", "test_enum16", valueColDef = "Enum16('small' = 1, 'medium' = 100, 'large' = 1000)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -698,7 +698,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getFloat(1) - 3.14f) < 0.01f)
     }
   }
-  test("decode Int128 - large integers as Decimal") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - large integers as Decimal") {
     withKVTable("test_db", "test_int128", valueColDef = "Int128") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int128 VALUES
@@ -716,7 +716,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDecimal(1) != null)
     }
   }
-  test("decode Int128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - nullable with null values") {
     withKVTable("test_db", "test_int128_null", valueColDef = "Nullable(Int128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -770,7 +770,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode IntegerType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - min and max values") {
     withKVTable("test_db", "test_int", valueColDef = "Int32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int VALUES
@@ -787,7 +787,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode IntegerType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - nullable with null values") {
     withKVTable("test_db", "test_int_null", valueColDef = "Nullable(Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int_null VALUES
@@ -822,7 +822,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "8.8.8.8")
     }
   }
-  test("decode IPv4 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv4 - nullable with null values") {
     withKVTable("test_db", "test_ipv4_null", valueColDef = "Nullable(IPv4)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv4_null VALUES
@@ -858,7 +858,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) != null)
     }
   }
-  test("decode IPv6 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv6 - nullable with null values") {
     withKVTable("test_db", "test_ipv6_null", valueColDef = "Nullable(IPv6)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv6_null VALUES
@@ -880,11 +880,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
     withKVTable("test_db", "test_json_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
-          """INSERT INTO $actualDb.test_json_null VALUES
-            |(1, '{"name": "Alice", "age": 30}'),
-            |(2, NULL),
-            |(3, '{"name": "Charlie", "age": 35}')
-            |""".stripMargin
+          s"""INSERT INTO $actualDb.test_json_null VALUES
+             |(1, '{"name": "Alice", "age": 30}'),
+             |(2, NULL),
+             |(3, '{"name": "Charlie", "age": 35}')
+             |""".stripMargin
         )
 
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -898,11 +898,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   test("decode JSON - semi-structured data") {
     withKVTable("test_db", "test_json", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
-        """INSERT INTO $actualDb.test_json VALUES
-          |(1, '{"name": "Alice", "age": 30}'),
-          |(2, '{"name": "Bob", "age": 25}'),
-          |(3, '{"name": "Charlie", "age": 35}')
-          |""".stripMargin
+        s"""INSERT INTO $actualDb.test_json VALUES
+           |(1, '{"name": "Alice", "age": 30}'),
+           |(2, '{"name": "Bob", "age": 25}'),
+           |(3, '{"name": "Charlie", "age": 35}')
+           |""".stripMargin
       )
 
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -913,7 +913,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1).contains("Charlie"))
     }
   }
-  test("decode LongType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - min and max values") {
     withKVTable("test_db", "test_long", valueColDef = "Int64") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long VALUES
@@ -930,7 +930,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode LongType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - nullable with null values") {
     withKVTable("test_db", "test_long_null", valueColDef = "Nullable(Int64)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long_null VALUES
@@ -982,7 +982,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode MapType - Map of String to Int") { (actualDb: String, actualTbl: String) =>
+  test("decode MapType - Map of String to Int") {
     withKVTable("test_db", "test_map", valueColDef = "Map(String, Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_map VALUES
@@ -1037,7 +1037,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ShortType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ShortType - nullable with null values") {
     withKVTable("test_db", "test_short_null", valueColDef = "Nullable(Int16)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1090,7 +1090,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode StringType - empty strings") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - empty strings") {
     withKVTable("test_db", "test_empty_string", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_empty_string VALUES
@@ -1108,7 +1108,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "")
     }
   }
-  test("decode StringType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - nullable with null values") {
     withKVTable("test_db", "test_string_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1140,11 +1140,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
-        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$$%^&*()") :: Nil
+        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$%^&*()") :: Nil
       )
     }
   }
-  test("decode StringType - UUID") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID") {
     withKVTable("test_db", "test_uuid", valueColDef = "UUID") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid VALUES
@@ -1160,7 +1160,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getString(1) == "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
     }
   }
-  test("decode StringType - UUID nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID nullable with null values") {
     withKVTable("test_db", "test_uuid_null", valueColDef = "Nullable(UUID)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid_null VALUES
@@ -1193,7 +1193,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(0).getString(1).length == 10000)
     }
   }
-  test("decode TimestampType - DateTime") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime") {
     withKVTable("test_db", "test_datetime", valueColDef = "DateTime") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime VALUES
@@ -1211,7 +1211,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getTimestamp(1) != null)
     }
   }
-  test("decode TimestampType - DateTime64") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime64") {
     withKVTable("test_db", "test_datetime64", valueColDef = "DateTime64(3)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime64 VALUES
@@ -1283,7 +1283,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt128 - nullable with null values") {
     withKVTable("test_db", "test_uint128_null", valueColDef = "Nullable(UInt128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1337,7 +1337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode UInt256 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt256 - nullable with null values") {
     withKVTable("test_db", "test_uint256_null", valueColDef = "Nullable(UInt256)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1372,7 +1372,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt64 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt64 - nullable with null values") {
     withKVTable("test_db", "test_uint64_null", valueColDef = "Nullable(UInt64)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1388,14 +1388,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 5)
-        assert(result(0).getDecimal(1) == BigDecimal(0))
+        assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
         assert(result(1).isNullAt(1))
         // Test value just above Long.MAX_VALUE
-        assert(result(2).getDecimal(1) == BigDecimal("9223372036854775808"))
+        assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775808"))
         // Test large value in the middle range
-        assert(result(3).getDecimal(1) == BigDecimal("15000000000000000000"))
+        assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("15000000000000000000"))
         // Test maximum UInt64 value (2^64 - 1)
-        assert(result(4).getDecimal(1) == BigDecimal("18446744073709551615"))
+        assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
   test("decode UInt64 - unsigned 64-bit integers") {
@@ -1414,20 +1414,20 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 6)
-      assert(result(0).getDecimal(1) == BigDecimal(0))
-      assert(result(1).getDecimal(1) == BigDecimal("1234567890"))
+      assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
+      assert(BigDecimal(result(1).getDecimal(1)) == BigDecimal("1234567890"))
       // Max value that fits in signed Long
-      assert(result(2).getDecimal(1) == BigDecimal("9223372036854775807"))
+      assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775807"))
       // Test value just above Long.MAX_VALUE (proves DecimalType works)
-      assert(result(3).getDecimal(1) == BigDecimal("9223372036854775808"))
+      assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("9223372036854775808"))
       // Test large value in the middle range
-      assert(result(4).getDecimal(1) == BigDecimal("15000000000000000000"))
+      assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("15000000000000000000"))
       // Test maximum UInt64 value (2^64 - 1)
-      assert(result(5).getDecimal(1) == BigDecimal("18446744073709551615"))
+      assert(BigDecimal(result(5).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
 
-  test("decode StructType - unnamed tuple created directly in ClickHouse") { (actualDb: String, actualTbl: String) =>
+  test("decode StructType - unnamed tuple created directly in ClickHouse") {
     val db = "test_db"
     val tbl = "test_read_unnamed_tuple"
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -58,6 +58,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       .option("password", clickhousePassword)
       .option("database", db)
       .option("table", tbl)
+      .option("ssl", isSslEnabled.toString)
       .load()
 
     val tableProviderDFSelected = if (columns == "*") {

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -36,7 +36,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   ))
 
   test("write and read using format API") {
-    withTable("format_api_db", "test_format_api", testSchema) {
+    withTable("format_api_db", "test_format_api", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -75,7 +75,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("append mode adds data without replacing existing") {
-    withTable("append_db", "test_append", testSchema) {
+    withTable("append_db", "test_append", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -108,7 +108,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("overwrite mode replaces all existing data") {
-    withTable("overwrite_db", "test_overwrite", testSchema) {
+    withTable("overwrite_db", "test_overwrite", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -198,7 +198,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("predicate pushdown filters data server-side") {
-    withTable("filter_db", "test_filter", testSchema) {
+    withTable("filter_db", "test_filter", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -308,7 +308,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("column pruning reduces data transfer") {
-    withTable("prune_db", "test_prune", testSchema) {
+    withTable("prune_db", "test_prune", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -370,7 +370,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       StructField("value", DoubleType, nullable = true)
     ))
 
-    withTable("null_db", "test_nulls", nullableSchema) {
+    withTable("null_db", "test_nulls", nullableSchema) { (_, _) =>
       val writeData = Seq(
         (1, Some("Alice"), Some(95.5)),
         (2, None, Some(87.3)),
@@ -402,7 +402,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("write empty dataframe") {
-    withTable("empty_db", "test_empty", testSchema) {
+    withTable("empty_db", "test_empty", testSchema) { (_, _) =>
       // Create empty DataFrame with proper schema
       val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
         .toDF("id", "name", "value", "created")

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
@@ -779,7 +779,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_simple_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_simple_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_simple_struct").sort("id").collect()
 
@@ -828,7 +828,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nested_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nested_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nested_struct").sort("id").collect()
 
@@ -867,7 +867,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nullable_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nullable_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nullable_struct").sort("id").collect()
 
@@ -905,7 +905,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_complex_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_complex_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_complex_struct").sort("id").collect()
 
@@ -952,7 +952,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_struct_array").append()
+      dataDF.writeTo(s"$actualDb.test_write_struct_array").append()
 
       val result = spark.table(s"$actualDb.test_write_struct_array").sort("id").collect()
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -104,7 +104,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     engine: String = "MergeTree()",
     sortKeys: Seq[String] = "id" :: Nil,
     partKeys: Seq[String] = Seq.empty
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -125,7 +125,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)
@@ -140,7 +140,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     tbl: String,
     keyColDef: String = "Int32",
     valueColDef: String
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -157,7 +157,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseDataTypeSuite.scala
@@ -51,7 +51,7 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
     val db = "t_w_s_db"
     val tbl = "t_w_s_tbl"
     withTable(db, tbl, schema) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       val respectNullable = SPARK_43390_ENABLED && !spark.conf.get(USE_NULLABLE_QUERY_SCHEMA)
       if (respectNullable) {
         // TODO nested field does not respect nullable
@@ -68,11 +68,11 @@ abstract class ClickHouseDataTypeSuite extends SparkClickHouseSingleTest {
       )).toDF("id", "col_string", "col_date", "col_array_string", "col_map_string_string")
 
       spark.createDataFrame(dataDF.rdd, tblSchema)
-        .writeTo(s"$db.$tbl")
+        .writeTo(s"$actualDb.$actualTbl")
         .append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("id"),
+        spark.table(s"$actualDb.$actualTbl").sort("id"),
         Row(1L, "a", date("1996-06-06"), Seq("a", "b", "c"), Map("a" -> "x")) ::
           Row(2L, "A", date("2022-04-12"), Seq("A", "B", "C"), Map("A" -> "X")) :: Nil
       )

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,7 +122,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) {
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -167,7 +167,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -212,7 +212,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) {
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES
@@ -292,7 +292,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) {
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
       spark.sql(
         s"""INSERT INTO `$db`.`$tbl`
            |VALUES

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -122,9 +122,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         StructField("id", LongType, false) ::
           StructField("date", DateType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("date")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("date")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11"),
            |  (12L, "2022-04-12") AS tab(id, date)
@@ -135,10 +135,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, date("2022-04-22"))
       ))
         .toDF("id", "date")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11")) ::
           Row(12L, date("2022-04-12")) ::
           Row(21L, date("2022-04-21")) ::
@@ -146,7 +146,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("date=2022-04-11"),
           Row("date=2022-04-12"),
@@ -167,9 +167,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", StringType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, part_1, part_2)
@@ -181,10 +181,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::
@@ -192,7 +192,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=1/part_2=1"),
           Row("part_1=1/part_2=2"),
@@ -212,9 +212,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("part_1", DateType, false) ::
           StructField("part_2", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (_, _) =>
+    withTable(db, tbl, schema, partKeys = Seq("part_1", "part_2")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, "2022-04-11", 1),
            |  (12L, "2022-04-12", 2) AS tab(id, part_1, part_2)
@@ -224,10 +224,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (21L, "2022-04-21", 1),
         (22L, "2022-04-22", 2)
       )).toDF("id", "part_1", "part_2")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, date("2022-04-11"), 1) ::
           Row(12L, date("2022-04-12"), 2) ::
           Row(21L, date("2022-04-21"), 1) ::
@@ -235,7 +235,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(
           Row("part_1=2022-04-11/part_2=1"),
           Row("part_1=2022-04-12/part_2=2"),
@@ -292,9 +292,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           StructField("sort_2", StringType, false) ::
           StructField("sort_3", IntegerType, false) :: Nil
       )
-    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (_, _) =>
+    withTable(db, tbl, schema, sortKeys = Seq("sort_2", "sort_3")) { (actualDb, actualTbl) =>
       spark.sql(
-        s"""INSERT INTO `$db`.`$tbl`
+        s"""INSERT INTO `$actualDb`.`$actualTbl`
            |VALUES
            |  (11L, 'one_one', '1', 1),
            |  (12L, 'one_two', '1', 2) AS tab(id, value, sort_2, sort_3)
@@ -306,10 +306,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         (22L, "two_two", "2", 2)
       ))
         .toDF("id", "value", "sort_2", "sort_3")
-        .writeTo(s"$db.$tbl").append
+        .writeTo(s"$actualDb.$actualTbl").append
 
       checkAnswer(
-        spark.table(s"$db.$tbl").orderBy($"id"),
+        spark.table(s"$actualDb.$actualTbl").orderBy($"id"),
         Row(11L, "one_one", "1", 1) ::
           Row(12L, "one_two", "1", 2) ::
           Row(21L, "two_one", "2", 1) ::

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -1433,12 +1433,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   // ============================================================================
 
   test("decode StructType - unnamed tuple created directly in ClickHouse") {
-    val db = "test_db"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "test_db"
     val tbl = "test_read_unnamed_tuple"
 
     try {
-      // Create database
-      runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      // Create database only if not using suite level database
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS $db")
+      }
 
       // Create table directly in ClickHouse with unnamed tuple
       runClickHouseSQL(
@@ -1489,8 +1491,12 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(data2.getInt(1) === 35)
       assert(data2.getString(2) === "SF")
 
-    } finally
-      runClickHouseSQL(s"DROP TABLE IF EXISTS $db.$tbl")
+    } finally {
+      dropTableWithRetry(db, tbl)
+      if (!useSuiteLevelDatabase) {
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
+      }
+    }
   }
 
   // ============================================================================

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -255,7 +255,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       }
     }
   }
-  test("decode BooleanType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode BooleanType - nullable with null values") {
     withKVTable("test_db", "test_bool_null", valueColDef = "Nullable(Bool)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_bool_null VALUES
@@ -304,7 +304,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ByteType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ByteType - nullable with null values") {
     withKVTable("test_db", "test_byte_null", valueColDef = "Nullable(Int8)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_byte_null VALUES
@@ -337,7 +337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getTimestamp(1) != null)
     }
   }
-  test("decode DateTime32 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateTime32 - nullable with null values") {
     withKVTable("test_db", "test_datetime32_null", valueColDef = "Nullable(DateTime32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -374,7 +374,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32") {
     withKVTable("test_db", "test_date32", valueColDef = "Date32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_date32 VALUES
@@ -392,7 +392,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDate(1) != null)
     }
   }
-  test("decode DateType - Date32 nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode DateType - Date32 nullable with null values") {
     withKVTable("test_db", "test_date32_null", valueColDef = "Nullable(Date32)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -582,7 +582,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getDouble(1) - 3.141592653589793) < 0.000001)
     }
   }
-  test("decode Enum16 - large enum") { (actualDb: String, actualTbl: String) =>
+  test("decode Enum16 - large enum") {
     withKVTable("test_db", "test_enum16", valueColDef = "Enum16('small' = 1, 'medium' = 100, 'large' = 1000)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -698,7 +698,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(math.abs(result(2).getFloat(1) - 3.14f) < 0.01f)
     }
   }
-  test("decode Int128 - large integers as Decimal") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - large integers as Decimal") {
     withKVTable("test_db", "test_int128", valueColDef = "Int128") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int128 VALUES
@@ -716,7 +716,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getDecimal(1) != null)
     }
   }
-  test("decode Int128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode Int128 - nullable with null values") {
     withKVTable("test_db", "test_int128_null", valueColDef = "Nullable(Int128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -770,7 +770,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode IntegerType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - min and max values") {
     withKVTable("test_db", "test_int", valueColDef = "Int32") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int VALUES
@@ -787,7 +787,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode IntegerType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IntegerType - nullable with null values") {
     withKVTable("test_db", "test_int_null", valueColDef = "Nullable(Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_int_null VALUES
@@ -822,7 +822,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "8.8.8.8")
     }
   }
-  test("decode IPv4 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv4 - nullable with null values") {
     withKVTable("test_db", "test_ipv4_null", valueColDef = "Nullable(IPv4)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv4_null VALUES
@@ -858,7 +858,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) != null)
     }
   }
-  test("decode IPv6 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode IPv6 - nullable with null values") {
     withKVTable("test_db", "test_ipv6_null", valueColDef = "Nullable(IPv6)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_ipv6_null VALUES
@@ -880,11 +880,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
     withKVTable("test_db", "test_json_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
-          """INSERT INTO $actualDb.test_json_null VALUES
-            |(1, '{"name": "Alice", "age": 30}'),
-            |(2, NULL),
-            |(3, '{"name": "Charlie", "age": 35}')
-            |""".stripMargin
+          s"""INSERT INTO $actualDb.test_json_null VALUES
+             |(1, '{"name": "Alice", "age": 30}'),
+             |(2, NULL),
+             |(3, '{"name": "Charlie", "age": 35}')
+             |""".stripMargin
         )
 
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -898,11 +898,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   test("decode JSON - semi-structured data") {
     withKVTable("test_db", "test_json", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
-        """INSERT INTO $actualDb.test_json VALUES
-          |(1, '{"name": "Alice", "age": 30}'),
-          |(2, '{"name": "Bob", "age": 25}'),
-          |(3, '{"name": "Charlie", "age": 35}')
-          |""".stripMargin
+        s"""INSERT INTO $actualDb.test_json VALUES
+           |(1, '{"name": "Alice", "age": 30}'),
+           |(2, '{"name": "Bob", "age": 25}'),
+           |(3, '{"name": "Charlie", "age": 35}')
+           |""".stripMargin
       )
 
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
@@ -913,7 +913,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1).contains("Charlie"))
     }
   }
-  test("decode LongType - min and max values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - min and max values") {
     withKVTable("test_db", "test_long", valueColDef = "Int64") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long VALUES
@@ -930,7 +930,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode LongType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode LongType - nullable with null values") {
     withKVTable("test_db", "test_long_null", valueColDef = "Nullable(Int64)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_long_null VALUES
@@ -982,7 +982,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode MapType - Map of String to Int") { (actualDb: String, actualTbl: String) =>
+  test("decode MapType - Map of String to Int") {
     withKVTable("test_db", "test_map", valueColDef = "Map(String, Int32)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_map VALUES
@@ -1037,7 +1037,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode ShortType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode ShortType - nullable with null values") {
     withKVTable("test_db", "test_short_null", valueColDef = "Nullable(Int16)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1090,7 +1090,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode StringType - empty strings") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - empty strings") {
     withKVTable("test_db", "test_empty_string", valueColDef = "String") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_empty_string VALUES
@@ -1108,7 +1108,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getString(1) == "")
     }
   }
-  test("decode StringType - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - nullable with null values") {
     withKVTable("test_db", "test_string_null", valueColDef = "Nullable(String)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1140,11 +1140,11 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       checkAnswer(
         df,
-        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$$%^&*()") :: Nil
+        Row(1, "hello") :: Row(2, "") :: Row(3, "world with spaces") :: Row(4, "special chars: !@#$%^&*()") :: Nil
       )
     }
   }
-  test("decode StringType - UUID") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID") {
     withKVTable("test_db", "test_uuid", valueColDef = "UUID") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid VALUES
@@ -1160,7 +1160,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getString(1) == "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
     }
   }
-  test("decode StringType - UUID nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode StringType - UUID nullable with null values") {
     withKVTable("test_db", "test_uuid_null", valueColDef = "Nullable(UUID)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_uuid_null VALUES
@@ -1193,7 +1193,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(0).getString(1).length == 10000)
     }
   }
-  test("decode TimestampType - DateTime") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime") {
     withKVTable("test_db", "test_datetime", valueColDef = "DateTime") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime VALUES
@@ -1211,7 +1211,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(2).getTimestamp(1) != null)
     }
   }
-  test("decode TimestampType - DateTime64") { (actualDb: String, actualTbl: String) =>
+  test("decode TimestampType - DateTime64") {
     withKVTable("test_db", "test_datetime64", valueColDef = "DateTime64(3)") { (actualDb: String, actualTbl: String) =>
       runClickHouseSQL(
         s"""INSERT INTO $actualDb.test_datetime64 VALUES
@@ -1283,7 +1283,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt128 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt128 - nullable with null values") {
     withKVTable("test_db", "test_uint128_null", valueColDef = "Nullable(UInt128)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1337,7 +1337,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       )
     }
   }
-  test("decode UInt256 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt256 - nullable with null values") {
     withKVTable("test_db", "test_uint256_null", valueColDef = "Nullable(UInt256)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1372,7 +1372,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       assert(result(1).getDecimal(1) != null)
     }
   }
-  test("decode UInt64 - nullable with null values") { (actualDb: String, actualTbl: String) =>
+  test("decode UInt64 - nullable with null values") {
     withKVTable("test_db", "test_uint64_null", valueColDef = "Nullable(UInt64)") {
       (actualDb: String, actualTbl: String) =>
         runClickHouseSQL(
@@ -1388,14 +1388,14 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
         val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
         val result = df.collect()
         assert(result.length == 5)
-        assert(result(0).getDecimal(1) == BigDecimal(0))
+        assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
         assert(result(1).isNullAt(1))
         // Test value just above Long.MAX_VALUE
-        assert(result(2).getDecimal(1) == BigDecimal("9223372036854775808"))
+        assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775808"))
         // Test large value in the middle range
-        assert(result(3).getDecimal(1) == BigDecimal("15000000000000000000"))
+        assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("15000000000000000000"))
         // Test maximum UInt64 value (2^64 - 1)
-        assert(result(4).getDecimal(1) == BigDecimal("18446744073709551615"))
+        assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
   test("decode UInt64 - unsigned 64-bit integers") {
@@ -1414,16 +1414,16 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       val df = readTableWithBothAPIs(actualDb, actualTbl, columns = "key, value", orderBy = Some("key"))
       val result = df.collect()
       assert(result.length == 6)
-      assert(result(0).getDecimal(1) == BigDecimal(0))
-      assert(result(1).getDecimal(1) == BigDecimal("1234567890"))
+      assert(BigDecimal(result(0).getDecimal(1)) == BigDecimal(0))
+      assert(BigDecimal(result(1).getDecimal(1)) == BigDecimal("1234567890"))
       // Max value that fits in signed Long
-      assert(result(2).getDecimal(1) == BigDecimal("9223372036854775807"))
+      assert(BigDecimal(result(2).getDecimal(1)) == BigDecimal("9223372036854775807"))
       // Test value just above Long.MAX_VALUE (proves DecimalType works)
-      assert(result(3).getDecimal(1) == BigDecimal("9223372036854775808"))
+      assert(BigDecimal(result(3).getDecimal(1)) == BigDecimal("9223372036854775808"))
       // Test large value in the middle range
-      assert(result(4).getDecimal(1) == BigDecimal("15000000000000000000"))
+      assert(BigDecimal(result(4).getDecimal(1)) == BigDecimal("15000000000000000000"))
       // Test maximum UInt64 value (2^64 - 1)
-      assert(result(5).getDecimal(1) == BigDecimal("18446744073709551615"))
+      assert(BigDecimal(result(5).getDecimal(1)) == BigDecimal("18446744073709551615"))
     }
   }
 
@@ -1431,7 +1431,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
   // StructType Tests
   // ============================================================================
 
-  test("decode StructType - unnamed tuple created directly in ClickHouse") { (actualDb: String, actualTbl: String) =>
+  test("decode StructType - unnamed tuple created directly in ClickHouse") {
     val db = "test_db"
     val tbl = "test_read_unnamed_tuple"
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -59,6 +59,7 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       .option("password", clickhousePassword)
       .option("database", db)
       .option("table", tbl)
+      .option("ssl", isSslEnabled.toString)
       .load()
 
     val tableProviderDFSelected = if (columns == "*") {

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseTableProviderSuite.scala
@@ -36,7 +36,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   ))
 
   test("write and read using format API") {
-    withTable("format_api_db", "test_format_api", testSchema) {
+    withTable("format_api_db", "test_format_api", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -75,7 +75,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("append mode adds data without replacing existing") {
-    withTable("append_db", "test_append", testSchema) {
+    withTable("append_db", "test_append", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -108,7 +108,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("overwrite mode replaces all existing data") {
-    withTable("overwrite_db", "test_overwrite", testSchema) {
+    withTable("overwrite_db", "test_overwrite", testSchema) { (_, _) =>
       val initialData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -198,7 +198,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("predicate pushdown filters data server-side") {
-    withTable("filter_db", "test_filter", testSchema) {
+    withTable("filter_db", "test_filter", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z")),
@@ -308,7 +308,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("column pruning reduces data transfer") {
-    withTable("prune_db", "test_prune", testSchema) {
+    withTable("prune_db", "test_prune", testSchema) { (_, _) =>
       val writeData = Seq(
         (1, "Alice", 95.5, timestamp("2024-01-15T10:00:00Z")),
         (2, "Bob", 87.3, timestamp("2024-02-20T14:30:00Z"))
@@ -370,7 +370,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
       StructField("value", DoubleType, nullable = true)
     ))
 
-    withTable("null_db", "test_nulls", nullableSchema) {
+    withTable("null_db", "test_nulls", nullableSchema) { (_, _) =>
       val writeData = Seq(
         (1, Some("Alice"), Some(95.5)),
         (2, None, Some(87.3)),
@@ -402,7 +402,7 @@ abstract class ClickHouseTableProviderSuite extends SparkClickHouseSingleTest {
   }
 
   test("write empty dataframe") {
-    withTable("empty_db", "test_empty", testSchema) {
+    withTable("empty_db", "test_empty", testSchema) { (_, _) =>
       // Create empty DataFrame with proper schema
       val emptyData = Seq.empty[(Int, String, Double, java.sql.Timestamp)]
         .toDF("id", "name", "value", "created")

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseWriterTestBase.scala
@@ -782,7 +782,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_simple_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_simple_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_simple_struct").sort("id").collect()
 
@@ -831,7 +831,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nested_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nested_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nested_struct").sort("id").collect()
 
@@ -870,7 +870,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_nullable_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_nullable_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_nullable_struct").sort("id").collect()
 
@@ -908,7 +908,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_complex_struct").append()
+      dataDF.writeTo(s"$actualDb.test_write_complex_struct").append()
 
       val result = spark.table(s"$actualDb.test_write_complex_struct").sort("id").collect()
 
@@ -955,7 +955,7 @@ trait ClickHouseWriterTestBase extends SparkClickHouseSingleTest {
         schema
       )
 
-      dataDF.writeTo("$actualDb.test_write_struct_array").append()
+      dataDF.writeTo(s"$actualDb.test_write_struct_array").append()
 
       val result = spark.table(s"$actualDb.test_write_struct_array").sort("id").collect()
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -102,7 +102,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     engine: String = "MergeTree()",
     sortKeys: Seq[String] = "id" :: Nil,
     partKeys: Seq[String] = Seq.empty
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -123,7 +123,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)
@@ -138,7 +138,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     tbl: String,
     keyColDef: String = "Int32",
     valueColDef: String
-  )(f: => Unit): Unit = {
+  )(f: (String, String) => Unit): Unit = {
     val actualDb = if (useSuiteLevelDatabase) testDatabaseName else db
     try {
       if (!useSuiteLevelDatabase) {
@@ -155,7 +155,7 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
 
       if (isCloud) Thread.sleep(1000)
 
-      f
+      f(actualDb, tbl)
     } finally
       if (useSuiteLevelDatabase) {
         dropTableWithRetry(actualDb, tbl)


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where test helper functions (`withTable`, `withKVTable`) were not actually executing test bodies, causing tests to silently pass without running any assertions.

## Problem

The test helper functions in `SparkClickHouseSingleTest.scala` were defined with by-name parameters:

def withTable(...)(f: => Unit): Unit
def withKVTable(...)(f: => Unit): Unit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes but they alter shared fixtures and many integration tests; risk is limited to CI behavior and potential new failures due to previously non-executed assertions now running.
> 
> **Overview**
> **Makes ClickHouse Spark ITs actually execute assertions.** Updates `withTable`/`withKVTable` (Spark 3.3–4.0) to accept `(actualDb, actualTbl)` and invokes the callback, then refactors affected suites to use those returned names instead of the requested `db/tbl`.
> 
> **Fixes several test correctness issues that previously let tests silently pass.** Removes accidental function-literal test bodies in `ClickHouseReaderTestBase`, fixes missing string interpolation in `INSERT` statements and `writeTo` targets, adds `.option("ssl", ...)` for TableProvider reads, and hardens a few assertions (e.g., `UInt64` decimal comparisons and expected `$` escaping in strings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 296974be5807826d0393f455d5a1a4fe4f01e469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->