### PR TITLE
fix: replace custom_http_params with clickhouse_setting_ prefix in cl…

### DIFF
--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -75,7 +75,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.sql.catalog.clickhouse.user", clickhouseUser)
     .set("spark.sql.catalog.clickhouse.password", clickhousePassword)
     .set("spark.sql.catalog.clickhouse.database", clickhouseDatabase)
-    .set("spark.sql.catalog.clickhouse.option.custom_http_params", "async_insert=1,wait_for_async_insert=1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_wait_for_async_insert", "1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert_deduplicate", "0")
     .set("spark.sql.catalog.clickhouse.option.ssl", isSslEnabled.toString)
     // extended configurations
     .set("spark.clickhouse.write.batchSize", "2")
@@ -93,7 +94,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     "user" -> clickhouseUser,
     "password" -> clickhousePassword,
     "database" -> clickhouseDatabase,
-    "option.custom_http_params" -> "async_insert=1,wait_for_async_insert=1",
+    "option.clickhouse_setting_wait_for_async_insert" -> "1",
+    "option.clickhouse_setting_async_insert_deduplicate" -> "0",
     "option.ssl" -> isSslEnabled.toString
   )
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -74,7 +74,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.sql.catalog.clickhouse.user", clickhouseUser)
     .set("spark.sql.catalog.clickhouse.password", clickhousePassword)
     .set("spark.sql.catalog.clickhouse.database", clickhouseDatabase)
-    .set("spark.sql.catalog.clickhouse.option.custom_http_params", "async_insert=1,wait_for_async_insert=1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_wait_for_async_insert", "1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert_deduplicate", "0")
     .set("spark.sql.catalog.clickhouse.option.ssl", isSslEnabled.toString)
     // extended configurations
     .set("spark.clickhouse.write.batchSize", "2")
@@ -92,7 +93,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     "user" -> clickhouseUser,
     "password" -> clickhousePassword,
     "database" -> clickhouseDatabase,
-    "option.custom_http_params" -> "async_insert=1,wait_for_async_insert=1",
+    "option.clickhouse_setting_wait_for_async_insert" -> "1",
+    "option.clickhouse_setting_async_insert_deduplicate" -> "0",
     "option.ssl" -> isSslEnabled.toString
   )
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -75,7 +75,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     .set("spark.sql.catalog.clickhouse.user", clickhouseUser)
     .set("spark.sql.catalog.clickhouse.password", clickhousePassword)
     .set("spark.sql.catalog.clickhouse.database", clickhouseDatabase)
-    .set("spark.sql.catalog.clickhouse.option.custom_http_params", "async_insert=1,wait_for_async_insert=1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_wait_for_async_insert", "1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert_deduplicate", "0")
     .set("spark.sql.catalog.clickhouse.option.ssl", isSslEnabled.toString)
     // extended configurations
     .set("spark.clickhouse.write.batchSize", "2")
@@ -93,7 +94,8 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider
     "user" -> clickhouseUser,
     "password" -> clickhousePassword,
     "database" -> clickhouseDatabase,
-    "option.custom_http_params" -> "async_insert=1,wait_for_async_insert=1",
+    "option.clickhouse_setting_wait_for_async_insert" -> "1",
+    "option.clickhouse_setting_async_insert_deduplicate" -> "0",
     "option.ssl" -> isSslEnabled.toString
   )
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/SparkClickHouseSingleTest.scala
@@ -73,7 +73,9 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     .set("spark.sql.catalog.clickhouse.user", clickhouseUser)
     .set("spark.sql.catalog.clickhouse.password", clickhousePassword)
     .set("spark.sql.catalog.clickhouse.database", clickhouseDatabase)
-    .set("spark.sql.catalog.clickhouse.option.custom_http_params", "async_insert=1,wait_for_async_insert=1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert", "1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_wait_for_async_insert", "1")
+    .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert_deduplicate", "0")
     .set("spark.sql.catalog.clickhouse.option.ssl", isSslEnabled.toString)
     // extended configurations
     .set("spark.clickhouse.write.batchSize", "2")
@@ -91,7 +93,9 @@ trait SparkClickHouseSingleTest extends SparkTest with ClickHouseProvider with B
     "user" -> clickhouseUser,
     "password" -> clickhousePassword,
     "database" -> clickhouseDatabase,
-    "option.custom_http_params" -> "async_insert=1,wait_for_async_insert=1",
+    "option.clickhouse_setting_async_insert" -> "1",
+    "option.clickhouse_setting_wait_for_async_insert" -> "1",
+    "option.clickhouse_setting_async_insert_deduplicate" -> "0",
     "option.ssl" -> isSslEnabled.toString
   )
 


### PR DESCRIPTION
ClickHouse Cloud enables `async_insert=1` by default.
  With async inserts, writes return immediately - data sits in an in-memory buffer and is flushed to storage asynchronously.

  The test suite was setting `wait_for_async_insert=1` and `async_insert_deduplicate=0` via `custom_http_params`:

  ```scala
  .set("spark.sql.catalog.clickhouse.option.custom_http_params",
       "async_insert=1,wait_for_async_insert=1")
  ```

  **Java client v2 silently ignores `custom_http_params`.**
  It only processes options prefixed with `clickhouse_setting_`.
  So these settings never reached ClickHouse — every write returned before the data was flushed.

  This caused two failure modes:

  - **Race condition** - reads ran before the async buffer was flushed, seeing 0 rows instead of the expected count
  - **Silent deduplication** - `async_insert_deduplicate=1` (Cloud default) caused repeated test runs to silently drop rows it considered duplicates

  ## The Fix

  Replace `custom_http_params` with individual `clickhouse_setting_` prefixed options in both `sparkConf` and `cmdRunnerOptions` across all Spark versions (3.3, 3.4, 3.5, 4.0):

  ```scala
  // Before (ignored by Java client v2)
  .set("spark.sql.catalog.clickhouse.option.custom_http_params",
       "async_insert=1,wait_for_async_insert=1")

  // After (actually sent to ClickHouse)
  .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_wait_for_async_insert", "1")
  .set("spark.sql.catalog.clickhouse.option.clickhouse_setting_async_insert_deduplicate", "0")
  ```

  - `wait_for_async_insert=1` — makes INSERT block until the async buffer is flushed and data is committed, so reads always see it
  - `async_insert_deduplicate=0` — disables deduplication, preventing silent data drops on repeated test runs