### PR TITLE
Upgrade clickhouse-java to 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Changes that have been merged but not yet released will be documented here.
 ### Changed
 - **Breaking Change**: Default value of `spark.clickhouse.ignoreUnsupportedTransform` changed from `false` to `true` ([#499](https://github.com/ClickHouse/spark-clickhouse-connector/pull/499)). Writes to tables with unsupported partition/sharding expressions (e.g., `PARTITION BY tuple()`, `PARTITION BY substring(...)`) now log a warning and continue instead of failing. To restore the old fail-fast behavior, set `spark.clickhouse.ignoreUnsupportedTransform=false`. **Warning**: For Distributed tables with `spark.clickhouse.write.distributed.convertLocal=true`, unsupported sharding keys may cause data corruption. The connector validates this and throws an error by default. To allow it, explicitly set `spark.clickhouse.write.distributed.convertLocal.allowUnsupportedSharding=true`.
 
+### Dependencies
+- Updated clickhouse-java version from `0.9.5` to `0.9.6`
+
 ### Fixed
 - Fixed UInt64 type mapping to prevent data loss and overflow ([#477](https://github.com/ClickHouse/spark-clickhouse-connector/pull/477)). ClickHouse `UInt64` type (range: 0 to 18446744073709551615) is now mapped to Spark `DecimalType(20, 0)` instead of `LongType` to safely handle the full value range without overflow. Previously, values greater than 9223372036854775807 (Long.MAX_VALUE) would overflow or lose precision.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ systemProp.known_spark_binary_versions=3.3,3.4,3.5,4.0
 
 group=com.clickhouse.spark
 
-clickhouse_jdbc_version=0.9.5
-clickhouse_client_v2_version=0.9.5
+clickhouse_jdbc_version=0.9.6
+clickhouse_client_v2_version=0.9.6
 
 spark_33_version=3.3.4
 spark_34_version=3.4.2


### PR DESCRIPTION
## Summary
* Upgrades `com.clickhouse` Java client from `0.9.5` to `0.9.6`
* All 357 unit tests passing

## Changes
- Updated `clickhouse_jdbc_version` and `clickhouse_client_v2_version` in `gradle.properties` from `0.9.5` to `0.9.6`
- Updated CHANGELOG.md

## Notes
- Versions `0.9.7` and `0.9.8` fail with `ClientMisconfigurationException: Unknown and unmapped config properties: [ssl]` — a breaking API change in the client-v2 SSL configuration. The connector's `NodeClient` passes an `ssl` property that was removed/renamed in 0.9.7+. A separate code change would be needed to support those versions.

## Test plan
- [x] Unit tests pass with `./gradlew clean test` (357 passed, 0 failed)
- [ ] Integration tests (manual verification recommended)
- [ ] Verify connector functionality end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)