### PR TITLE
fix: remove false-positive Databricks signatures from RuntimeDetector

### DIFF
--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/Utils.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/Utils.scala
@@ -196,7 +196,10 @@ object Utils extends Logging {
         .orElse(RuntimeDetector.detectViaThreadNames())
 
     /**
-     * Examines the current stack trace and loaded classes for platform-specific signatures
+     * Examines the current stack trace and loaded classes for platform-specific signatures.
+     * Platforms are checked from most class-exclusive to least, with Databricks last because
+     * some of its class patterns (e.g. databricks.spark.*) leak into open-source libraries
+     * such as delta-spark and can produce false positives on other platforms.
      */
     def detectViaStackTrace(): Option[String] = {
       val stackTrace = Thread.currentThread().getStackTrace
@@ -204,14 +207,6 @@ object Utils extends Logging {
 
       // Check for platform-specific classes in stack
       if (
-        stackClasses.exists(c =>
-          c.contains("com.databricks.logging") ||
-            c.contains("databricks.spark") ||
-            c.contains("com.databricks.backend")
-        )
-      ) {
-        Some("Databricks")
-      } else if (
         stackClasses.exists { c =>
           c.contains("com.amazonaws.services.glue") ||
           c.contains("aws.glue") ||
@@ -240,29 +235,29 @@ object Utils extends Logging {
         )
       ) {
         Some("Synapse")
+      } else if (
+        stackClasses.exists(c =>
+          c.contains("com.databricks.backend")
+        )
+      ) {
+        Some("Databricks")
       } else {
         None
       }
     }
 
     /**
-     * More comprehensive check using ClassLoader to find platform-specific classes
+     * More comprehensive check using ClassLoader to find platform-specific classes.
+     * Only platform-internal classes are listed (not present in any public Maven artifact).
+     * Platforms are ordered from most class-exclusive to least, with Databricks last because
+     * open-source libraries (e.g. delta-spark) have historically leaked Databricks class names.
      */
-    def detectViaClassLoader(): Option[String] = {
-      val classLoader = Thread.currentThread().getContextClassLoader
-
+    def detectViaClassLoader(
+      classExists: String => Boolean = defaultClassExists
+    ): Option[String] = {
       case class PlatformSignature(name: String, classNames: Seq[String])
 
       val platformSignatures = Seq(
-        PlatformSignature(
-          "Databricks",
-          Seq(
-            "com.databricks.spark.util.DatabricksLogging",
-            "com.databricks.backend.daemon.driver.DriverLocal",
-            "com.databricks.dbutils_v1.DBUtilsHolder",
-            "com.databricks.spark.util.FrameProfiler"
-          )
-        ),
         PlatformSignature(
           "Glue",
           Seq(
@@ -275,16 +270,13 @@ object Utils extends Logging {
           "EMR",
           Seq(
             "com.amazon.ws.emr.hadoop.fs.EmrFileSystem",
-            "com.amazon.emr.kinesis.client.KinesisConnector",
             "com.amazon.emr.cloudwatch.CloudWatchSink"
           )
         ),
         PlatformSignature(
           "Dataproc",
           Seq(
-            "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
-            "com.google.cloud.dataproc.DataprocHadoopConfiguration",
-            "com.google.cloud.spark.bigquery.BigQueryConnector"
+            "com.google.cloud.dataproc.DataprocHadoopConfiguration"
           )
         ),
         PlatformSignature(
@@ -297,23 +289,30 @@ object Utils extends Logging {
         PlatformSignature(
           "HDInsight",
           Seq(
-            "com.microsoft.azure.hdinsight.spark.common.SparkBatchJob",
-            "com.microsoft.hdinsight.spark.common.HttpFutureCallback"
+            "com.microsoft.azure.hdinsight.spark.common.SparkBatchJob"
+          )
+        ),
+        PlatformSignature(
+          "Databricks",
+          Seq(
+            "com.databricks.backend.daemon.driver.DriverLocal",
+            "com.databricks.spark.util.FrameProfiler"
           )
         )
       )
 
-      // Try to load platform-specific classes
-      def classExists(className: String): Boolean =
-        try {
-          Class.forName(className, false, classLoader)
-          true
-        } catch {
-          case _: ClassNotFoundException => false
-        }
-
       platformSignatures.collectFirst {
         case PlatformSignature(name, classes) if classes.exists(classExists) => name
+      }
+    }
+
+    private def defaultClassExists(className: String): Boolean = {
+      val classLoader = Thread.currentThread().getContextClassLoader
+      try {
+        Class.forName(className, false, classLoader)
+        true
+      } catch {
+        case _: ClassNotFoundException => false
       }
     }
 


### PR DESCRIPTION
`com.databricks.spark.util.DatabricksLogging` is present in the open-source `delta-spark` library (e.g. delta-spark_2.12:3.0.0), which is bundled by AWS Glue 5.0. This caused Glue 5 environments to be misidentified as Databricks in detectViaClassLoader().

Changes:
- Move Databricks to last in the platform check order so more class-exclusive platforms (Glue, EMR, Dataproc) are matched first
- Remove DatabricksLogging and DBUtilsHolder from Databricks signatures (both present in public Maven artifacts)
- Remove leaked class names from EMR, Dataproc, HDInsight signatures
- Extract defaultClassExists as a named private method so the function can be injected in tests

Classes intentionally excluded (exist in public artifacts):
- com.databricks.spark.util.DatabricksLogging    (io.delta:delta-spark)
- com.databricks.dbutils_v1.DBUtilsHolder         (com.databricks:dbutils-api_2.12)
- com.amazon.emr.kinesis.client.KinesisConnector  (com.amazonaws:amazon-kinesis-connectors)
- com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem (com.google.cloud.bigdataoss:gcs-connector)
- com.google.cloud.spark.bigquery.BigQueryConnector     (com.google.cloud.spark:spark-bigquery-with-dependencies)
- com.microsoft.hdinsight.spark.common.HttpFutureCallback (azure-mgmt-hdinsight transitive dep)

Also reorders detectViaStackTrace() to check Databricks last for the same reason: databricks.spark.* patterns appear in delta-spark stack frames on non-Databricks platforms.

