### PR TITLE
ci: add nightly schedule and test against ClickHouse head

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,15 +22,18 @@ on:
     branches:
       - "branch-*"
       - "main"
+  schedule:
+    # Nightly run at 02:00 UTC
+    - cron: '0 2 * * *'
   workflow_dispatch:
-  
+
 jobs:
   run-tests:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ 25.6, 25.7, 25.8, 25.9, latest ]
+        clickhouse: [ 25.6, 25.7, 25.8, 25.9, latest, head ]
         java: [ 8, 17 ]
         scala: [ '2.12', '2.13' ]
         spark: [ '3.3', '3.4', '3.5', '4.0' ]

--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -23,6 +23,9 @@ on:
       - "branch-*"
       - "main"
     types: [opened, reopened, synchronize, labeled]
+  schedule:
+    # Nightly run at 02:00 UTC
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -30,11 +33,13 @@ jobs:
     runs-on: ubuntu-22.04
     # Run for:
     # - push to main
+    # - nightly schedule
     # - workflow_dispatch
     # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
     # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && (
         (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -23,6 +23,9 @@ on:
     branches:
       - "branch-*"
       - "main"
+  schedule:
+    # Nightly run at 02:00 UTC
+    - cron: '0 2 * * *'
 
 jobs:
   run-tpcds-sf1:


### PR DESCRIPTION
- Add a nightly cron (02:00 UTC) and workflow_dispatch where missing to build-and-test, cloud, and tpcds workflows so regressions against new ClickHouse releases are caught out of band from PR activity.
- Include `head` in the build-and-test ClickHouse matrix.
This resolves #454 ,  #455 