### PR TITLE
Preventing extra quotes in filter expr when cols have special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@ Changes that have been merged but not yet released will be documented here.
 ### Removed
 - gzip and zstd write compression support has been removed (currently supported codecs are `none`, `lz4` (default))
 
+## [Unreleased]
+
+### Fixed
+- Preventing extra quotes in filter expr when col having special characters
+
 [Unreleased]: https://github.com/ClickHouse/spark-clickhouse-connector/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/ClickHouse/spark-clickhouse-connector/releases/tag/v0.9.0
 [0.8.1]: https://github.com/ClickHouse/spark-clickhouse-connector/releases/tag/v0.8.1

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -14,7 +14,9 @@
 
 package org.apache.spark.sql.clickhouse.single
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 /**
  * Shared test cases for both JSON and Binary readers.
@@ -1491,6 +1493,41 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       if (!useSuiteLevelDatabase) {
         runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
       }
+    }
+  }
+
+  test("decode SpecialChar Cols: cols having space and applying filter") {
+    val schema: StructType = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("`space col`", StringType, nullable = true),
+      StructField("`1col`", StringType, nullable = true),
+      StructField("`hyphen-col`", StringType, nullable = true)
+    ))
+    withTable("test_db", "special_char_col", schema) {
+      (actualDb: String, actualTbl: String) =>
+        runClickHouseSQL(
+          s"""INSERT INTO $actualDb.special_char_col VALUES
+             |(1, NULL, NULL, NULL),
+             |(2, 'Bob', 'Bob2', 'Bob3')
+             |""".stripMargin
+        )
+
+        var df = readTableWithBothAPIs(
+          actualDb,
+          actualTbl,
+          columns = "id, `space col`, `1col`, `hyphen-col`",
+          orderBy = Some("id")
+        )
+        df = df.filter(col("space col").isNotNull)
+          .filter(col("1col").isNotNull)
+          .filter(col("hyphen-col").isNotNull)
+
+        val result = df.collect()
+        assert(result.length == 1)
+
+        assert(result(0).getString(1) == "Bob")
+        assert(result(0).getString(2) == "Bob2")
+        assert(result(0).getString(3) == "Bob3")
     }
   }
 

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,6 +16,7 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference
@@ -25,7 +26,13 @@ import com.clickhouse.spark.Utils._
 
 trait SQLHelper {
 
-  def quoted(token: String) = s"`$token`"
+  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
+
+  private def alreadyQuoted(part: String): Boolean =
+    !validIdentPattern.matcher(part).matches()
+
+  def quoted(token: String): String =
+    if (alreadyQuoted(token)) token else s"`$token`"
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -26,13 +26,10 @@ import com.clickhouse.spark.Utils._
 
 trait SQLHelper {
 
-  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
-
-  private def alreadyQuoted(part: String): Boolean =
-    !validIdentPattern.matcher(part).matches()
-
-  def quoted(token: String): String =
-    if (alreadyQuoted(token)) token else s"`$token`"
+  def quoted(token: String): String = token match {
+    case t if t.startsWith("`") && t.endsWith("`") => t
+    case t => s"`$t`"
+  }
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,7 +16,6 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
-import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -14,7 +14,9 @@
 
 package org.apache.spark.sql.clickhouse.single
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 /**
  * Shared test cases for both JSON and Binary readers.
@@ -1491,6 +1493,41 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       if (!useSuiteLevelDatabase) {
         runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
       }
+    }
+  }
+
+  test("decode SpecialChar Cols: cols having space and applying filter") {
+    val schema: StructType = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("`space col`", StringType, nullable = true),
+      StructField("`1col`", StringType, nullable = true),
+      StructField("`hyphen-col`", StringType, nullable = true)
+    ))
+    withTable("test_db", "special_char_col", schema) {
+      (actualDb: String, actualTbl: String) =>
+        runClickHouseSQL(
+          s"""INSERT INTO $actualDb.special_char_col VALUES
+             |(1, NULL, NULL, NULL),
+             |(2, 'Bob', 'Bob2', 'Bob3')
+             |""".stripMargin
+        )
+
+        var df = readTableWithBothAPIs(
+          actualDb,
+          actualTbl,
+          columns = "id, `space col`, `1col`, `hyphen-col`",
+          orderBy = Some("id")
+        )
+        df = df.filter(col("space col").isNotNull)
+          .filter(col("1col").isNotNull)
+          .filter(col("hyphen-col").isNotNull)
+
+        val result = df.collect()
+        assert(result.length == 1)
+
+        assert(result(0).getString(1) == "Bob")
+        assert(result(0).getString(2) == "Bob2")
+        assert(result(0).getString(3) == "Bob3")
     }
   }
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,6 +16,7 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference
@@ -25,7 +26,13 @@ import com.clickhouse.spark.Utils._
 
 trait SQLHelper {
 
-  def quoted(token: String) = s"`$token`"
+  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
+
+  private def alreadyQuoted(part: String): Boolean =
+    !validIdentPattern.matcher(part).matches()
+
+  def quoted(token: String): String =
+    if (alreadyQuoted(token)) token else s"`$token`"
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -26,13 +26,10 @@ import com.clickhouse.spark.Utils._
 
 trait SQLHelper {
 
-  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
-
-  private def alreadyQuoted(part: String): Boolean =
-    !validIdentPattern.matcher(part).matches()
-
-  def quoted(token: String): String =
-    if (alreadyQuoted(token)) token else s"`$token`"
+  def quoted(token: String): String = token match {
+    case t if t.startsWith("`") && t.endsWith("`") => t
+    case t => s"`$t`"
+  }
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,7 +16,6 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
-import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -14,7 +14,9 @@
 
 package org.apache.spark.sql.clickhouse.single
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
 
 /**
  * Shared test cases for both JSON and Binary readers.
@@ -1491,6 +1493,41 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
       if (!useSuiteLevelDatabase) {
         runClickHouseSQL(s"DROP DATABASE IF EXISTS $db")
       }
+    }
+  }
+
+  test("decode SpecialChar Cols: cols having space and applying filter") {
+    val schema: StructType = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("`space col`", StringType, nullable = true),
+      StructField("`1col`", StringType, nullable = true),
+      StructField("`hyphen-col`", StringType, nullable = true)
+    ))
+    withTable("test_db", "special_char_col", schema) {
+      (actualDb: String, actualTbl: String) =>
+        runClickHouseSQL(
+          s"""INSERT INTO $actualDb.special_char_col VALUES
+             |(1, NULL, NULL, NULL),
+             |(2, 'Bob', 'Bob2', 'Bob3')
+             |""".stripMargin
+        )
+
+        var df = readTableWithBothAPIs(
+          actualDb,
+          actualTbl,
+          columns = "id, `space col`, `1col`, `hyphen-col`",
+          orderBy = Some("id")
+        )
+        df = df.filter(col("space col").isNotNull)
+          .filter(col("1col").isNotNull)
+          .filter(col("hyphen-col").isNotNull)
+
+        val result = df.collect()
+        assert(result.length == 1)
+
+        assert(result(0).getString(1) == "Bob")
+        assert(result(0).getString(2) == "Bob2")
+        assert(result(0).getString(3) == "Bob3")
     }
   }
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,6 +16,7 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference
@@ -25,7 +26,13 @@ import Utils._
 
 trait SQLHelper {
 
-  def quoted(token: String) = s"`$token`"
+  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
+
+  private def alreadyQuoted(part: String): Boolean =
+    !validIdentPattern.matcher(part).matches()
+
+  def quoted(token: String): String =
+    if (alreadyQuoted(token)) token else s"`$token`"
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -26,13 +26,10 @@ import Utils._
 
 trait SQLHelper {
 
-  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
-
-  private def alreadyQuoted(part: String): Boolean =
-    !validIdentPattern.matcher(part).matches()
-
-  def quoted(token: String): String =
-    if (alreadyQuoted(token)) token else s"`$token`"
+  def quoted(token: String): String = token match {
+    case t if t.startsWith("`") && t.endsWith("`") => t
+    case t => s"`$t`"
+  }
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,7 +16,6 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
-import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseReaderTestBase.scala
@@ -14,6 +14,7 @@
 
 package org.apache.spark.sql.clickhouse.single
 
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.types._
 
@@ -2013,6 +2014,41 @@ trait ClickHouseReaderTestBase extends SparkClickHouseSingleTest {
 
       val json3 = variantToJson(result(2).get(1).asInstanceOf[org.apache.spark.unsafe.types.VariantVal])
       assert(json3.contains("2.718"))
+    }
+  }
+
+  test("decode SpecialChar Cols: cols having space and applying filter") {
+    val schema: StructType = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("`space col`", StringType, nullable = true),
+      StructField("`1col`", StringType, nullable = true),
+      StructField("`hyphen-col`", StringType, nullable = true)
+    ))
+    withTable("test_db", "special_char_col", schema) {
+      (actualDb: String, actualTbl: String) =>
+        runClickHouseSQL(
+          s"""INSERT INTO $actualDb.special_char_col VALUES
+             |(1, NULL, NULL, NULL),
+             |(2, 'Bob', 'Bob2', 'Bob3')
+             |""".stripMargin
+        )
+
+        var df = readTableWithBothAPIs(
+          actualDb,
+          actualTbl,
+          columns = "id, `space col`, `1col`, `hyphen-col`",
+          orderBy = Some("id")
+        )
+        df = df.filter(col("space col").isNotNull)
+          .filter(col("1col").isNotNull)
+          .filter(col("hyphen-col").isNotNull)
+
+        val result = df.collect()
+        assert(result.length == 1)
+
+        assert(result(0).getString(1) == "Bob")
+        assert(result(0).getString(2) == "Bob2")
+        assert(result(0).getString(3) == "Bob3")
     }
   }
 

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,6 +16,7 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference
@@ -25,7 +26,13 @@ import Utils._
 
 trait SQLHelper {
 
-  def quoted(token: String) = s"`$token`"
+  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
+
+  private def alreadyQuoted(part: String): Boolean =
+    !validIdentPattern.matcher(part).matches()
+
+  def quoted(token: String): String =
+    if (alreadyQuoted(token)) token else s"`$token`"
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -26,13 +26,10 @@ import Utils._
 
 trait SQLHelper {
 
-  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
-
-  private def alreadyQuoted(part: String): Boolean =
-    !validIdentPattern.matcher(part).matches()
-
-  def quoted(token: String): String =
-    if (alreadyQuoted(token)) token else s"`$token`"
+  def quoted(token: String): String = token match {
+    case t if t.startsWith("`") && t.endsWith("`") => t
+    case t => s"`$t`"
+  }
 
   // null => null, ' => ''
   def escapeSql(value: String): String = StringUtils.replace(value, "'", "''")

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/SQLHelper.scala
@@ -16,7 +16,6 @@ package com.clickhouse.spark
 
 import java.sql.{Date, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
-import java.util.regex.Pattern
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.connector.expressions.aggregate._
 import org.apache.spark.sql.connector.expressions.NamedReference


### PR DESCRIPTION
## Summary
Fixes #534: Prevent double quoting of column names in `SQLHelper`

Spark already quotes column names when needed, but the connector was quoting them again, causing invalid SQL for columns with spaces (e.g. \``space col\``). This fix ensures column names are only quoted if not already quoted.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials