### PR TITLE
feat: implement SupportsPushDownTopN (top-N pushdown) across spark-3.3/3.4/3.5/4.0

### DIFF
--- a/clickhouse-core/src/main/scala/com/clickhouse/spark/expr/ExprRender.scala
+++ b/clickhouse-core/src/main/scala/com/clickhouse/spark/expr/ExprRender.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.clickhouse.spark.expr
+
+import com.clickhouse.spark.Utils
+
+/**
+ * Renders `Expr` trees as ClickHouse SQL with identifier back-quoting.
+ *
+ * Use this on the pushdown path (e.g. `ORDER BY` in scan queries) where
+ * connector-emitted identifiers must round-trip safely even when they
+ * collide with ClickHouse reserved words. The DDL path keeps using
+ * `Expr.sql` directly because the user owns identifier quoting there.
+ */
+object ExprRender {
+
+  def render(expr: Expr): String = expr match {
+    case FieldRef(name) => Utils.wrapBackQuote(name)
+    case FuncExpr(name, args) => s"$name(${args.map(render).mkString(",")})"
+    case other => other.sql
+  }
+
+  def renderOrder(o: OrderExpr): String = {
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"${render(o.expr)} $direction $nulls"
+  }
+}

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -22,6 +22,7 @@ spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed tab
 spark.clickhouse.read.fixedStringAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.read.format|json|Serialize format for reading. Supported formats: json, binary|0.6.0
 spark.clickhouse.read.jsonAs|variant|[Spark 4.0+ only] Read ClickHouse JSON type as the specified Spark data type. Supported types: variant (VariantType), string|0.9.0
+spark.clickhouse.read.pushdown.topN|true|Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. When `true`, eligible sort orders combined with a LIMIT are translated into a ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.|0.10.1
 spark.clickhouse.read.runtimeFilter.enabled|false|Enable runtime filter for reading.|0.8.0
 spark.clickhouse.read.settings|<undefined>|Settings when read from ClickHouse. e.g. `final=1, max_execution_time=5`|0.9.0
 spark.clickhouse.read.splitByPartitionId|true|If `true`, construct input partition filter by virtual column `_partition_id`, instead of partition value. There are known bugs to assemble SQL predication by partition value. This feature requires ClickHouse Server v21.6+|0.4.0

--- a/docs/configurations/02_sql_configurations.md
+++ b/docs/configurations/02_sql_configurations.md
@@ -22,7 +22,7 @@ spark.clickhouse.read.distributed.convertLocal|true|When reading Distributed tab
 spark.clickhouse.read.fixedStringAs|binary|Read ClickHouse FixedString type as the specified Spark data type. Supported types: binary, string|0.8.0
 spark.clickhouse.read.format|json|Serialize format for reading. Supported formats: json, binary|0.6.0
 spark.clickhouse.read.jsonAs|variant|[Spark 4.0+ only] Read ClickHouse JSON type as the specified Spark data type. Supported types: variant (VariantType), string|0.9.0
-spark.clickhouse.read.pushdown.topN|true|Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. When `true`, eligible sort orders combined with a LIMIT are translated into a ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.|0.10.1
+spark.clickhouse.read.pushdown.topN|true|Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. When `true`, eligible sort orders combined with a LIMIT are translated into a ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across input partitions. When `false`, the `ORDER BY ... LIMIT n` is left for Spark to evaluate; plain `LIMIT n` queries (no `ORDER BY`) are unaffected.|0.10.1
 spark.clickhouse.read.runtimeFilter.enabled|false|Enable runtime filter for reading.|0.8.0
 spark.clickhouse.read.settings|<undefined>|Settings when read from ClickHouse. e.g. `final=1, max_execution_time=5`|0.9.0
 spark.clickhouse.read.splitByPartitionId|true|If `true`, construct input partition filter by virtual column `_partition_id`, instead of partition value. There are known bugs to assemble SQL predication by partition value. This feature requires ClickHouse Server v21.6+|0.4.0

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -43,12 +43,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse catalog") {
-    withDatabase("db_t1", "db_t2") {
-      spark.sql("CREATE DATABASE db_t1")
-      spark.sql("CREATE DATABASE db_t2")
+    val prefix = if (useSuiteLevelDatabase) s"${testDatabaseName}_cat" else "db_t"
+    val db1 = s"${prefix}1"
+    val db2 = s"${prefix}2"
+    withDatabase(db1, db2) {
+      spark.sql(s"CREATE DATABASE $db1")
+      spark.sql(s"CREATE DATABASE $db2")
       checkAnswer(
-        spark.sql("SHOW DATABASES LIKE 'db_t*'"),
-        Row("db_t1") :: Row("db_t2") :: Nil
+        spark.sql(s"SHOW DATABASES LIKE '${prefix}*'"),
+        Row(db1) :: Row(db2) :: Nil
       )
       spark.sql("USE system")
       checkAnswer(
@@ -431,9 +434,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      runClickHouseSQL(
+        if (isCloud) "SYSTEM FLUSH LOGS ON CLUSTER 'default'"
+        else "SYSTEM FLUSH LOGS"
+      ).collect()
+      val queryLogRef =
+        if (isCloud) "clusterAllReplicas('default', system, query_log)"
+        else "system.query_log"
       val recentQueries = runClickHouseSQL(
-        s"""SELECT query FROM system.query_log
+        s"""SELECT query FROM $queryLogRef
            |WHERE type = 'QueryFinish'
            |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -68,52 +68,51 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("clickhouse partition") {
     val db = "db_part"
-    val tbl = "tbl_part"
 
     // DROP + PURGE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 1) PURGE")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
 
     // DROP + TRUNCATE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"TRUNCATE TABLE $db.$tbl PARTITION(m = 1)")
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
@@ -253,9 +252,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   // TODO remove this hack version
   test("clickhouse partition toYYYYMMDD(toDate(col))") {
-    val db = "db_part_toYYYYMMDD_toDate"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_part_toYYYYMMDD_toDate"
     val tbl = "tbl_part_toYYYYMMDD_toDate"
-    autoCleanupTable(db, tbl) { case (db, tbl) =>
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       runClickHouseSQL(
         s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl` (
            |    `id` Int64,
@@ -284,7 +284,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(2L, "2022-06-07")
         )
       )
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("clickhouse multi sort columns") {
@@ -324,20 +329,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse truncate table") {
-    withClickHouseSingleIdTable("db_trunc", "tbl_trunc") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"TRUNCATE TABLE $db.$tbl")
-      assert(spark.table(s"$db.$tbl").count == 0)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_trunc", "tbl_trunc", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 0)
     }
   }
 
   test("clickhouse delete") {
-    withClickHouseSingleIdTable("db_del", "tbl_db_del") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"DELETE FROM $db.$tbl WHERE id < 5")
-      assert(spark.table(s"$db.$tbl").count == 5)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
     }
   }
 
@@ -346,7 +353,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val tbl = "tbl_rw"
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       assert(tblSchema == StructType(
         StructField("id", DataTypes.LongType, false) ::
           StructField("value", DataTypes.StringType, true) ::
@@ -355,7 +362,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       ))
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("m"),
+        spark.table(s"$actualDb.$actualTbl").sort("m"),
         Seq(
           Row(1L, "1", timestamp("2021-01-01T10:10:10Z"), 1),
           Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2)
@@ -363,11 +370,11 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.table(s"$db.$tbl").filter($"id" > 1),
+        spark.table(s"$actualDb.$actualTbl").filter($"id" > 1),
         Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2) :: Nil
       )
 
-      assert(spark.table(s"$db.$tbl").filter($"id" > 1).count === 1)
+      assert(spark.table(s"$actualDb.$actualTbl").filter($"id" > 1).count === 1)
 
     // infiniteLoop()
     }
@@ -379,7 +386,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT m, _partition_id FROM $db.$tbl ORDER BY m"),
+        spark.sql(s"SELECT m, _partition_id FROM $actualDb.$actualTbl ORDER BY m"),
         Seq(
           Row(1, "1"),
           Row(2, "2")
@@ -461,22 +468,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT COUNT(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT COUNT(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MIN(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MIN(id) FROM $actualDb.$actualTbl"),
         Seq(Row(1))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MAX(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MAX(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 1)
@@ -484,7 +491,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 2)
@@ -494,7 +501,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("create or replace table") {
-    autoCleanupTable("db_cor", "tbl_cor") { (db, tbl) =>
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_cor"
+    val tbl = "tbl_cor"
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       def createOrReplaceTable(): Unit = spark.sql(
         s"""CREATE OR REPLACE TABLE `$db`.`$tbl` (
            |  id Long NOT NULL
@@ -508,7 +518,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
       createOrReplaceTable()
       createOrReplaceTable()
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("cache table") {
@@ -517,12 +532,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       try {
-        spark.sql(s"CACHE TABLE $db.$tbl")
-        val cachedPlan = spark.sql(s"SELECT * FROM $db.$tbl").queryExecution.commandExecuted
+        spark.sql(s"CACHE TABLE $actualDb.$actualTbl")
+        val cachedPlan = spark.sql(s"SELECT * FROM $actualDb.$actualTbl").queryExecution.commandExecuted
           .find(node => spark.sharedState.cacheManager.lookupCachedData(node).isDefined)
         assert(cachedPlan.isDefined)
       } finally
-        spark.sql(s"UNCACHE TABLE $db.$tbl")
+        spark.sql(s"UNCACHE TABLE $actualDb.$actualTbl")
     }
   }
 
@@ -533,18 +548,18 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=false")
       checkAnswer(
-        spark.sql(s"SELECT id FROM $db.$tbl " +
+        spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
           s"WHERE id IN (" +
-          s"  SELECT id FROM $db.$tbl " +
+          s"  SELECT id FROM $actualDb.$actualTbl " +
           s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
           s")"),
         Row(1)
       )
 
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=true")
-      val df = spark.sql(s"SELECT id FROM $db.$tbl " +
+      val df = spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
         s"WHERE id IN (" +
-        s"  SELECT id FROM $db.$tbl " +
+        s"  SELECT id FROM $actualDb.$actualTbl " +
         s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
         s")")
       checkAnswer(df, Row(1))

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types._
 import org.scalatest.tags.Cloud
 
 @Cloud
-class ClickHouseCloudGenericSuite extends ClickHouseDataTypeSuite with ClickHouseCloudMixIn
+class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
 
-class ClickHouseSingleGenericSuite extends ClickHouseDataTypeSuite with ClickHouseSingleMixIn
+class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHouseSingleMixIn
 
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
@@ -392,8 +392,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("push down top N") {
     val db = "db_topn"
-    // Table name is suffixed with nanoTime so the system.query_log scan below
-    // matches only this run's queries.
+    // Avoid CREATE TABLE collisions across parallel Spark profiles in CI.
     val tbl = s"tbl_topn_${System.nanoTime()}"
     // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
     val schema = StructType(
@@ -411,18 +410,20 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
            |""".stripMargin
       ).collect()
 
-      checkAnswer(
-        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
-        Seq(Row(40L), Row(30L))
-      )
+      // Tag the query so we can pull it from system.query_log by log_comment.
+      val topNLogTag = java.util.UUID.randomUUID().toString
+      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
 
       runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
       val recentQueries = runClickHouseSQL(
         s"""SELECT query FROM system.query_log
            |WHERE type = 'QueryFinish'
-           |  AND query LIKE '%$actualDb%$actualTbl%'
-           |  AND query LIKE '%SELECT%'
-           |  AND event_time > now() - INTERVAL 60 SECOND
+           |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
       ).collect().map(_.getString(0))

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,7 +19,9 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -29,6 +31,11 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
+  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
@@ -74,50 +81,66 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     // DROP + PURGE
     withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
 
     // DROP + TRUNCATE
     withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
   }
 
@@ -345,9 +368,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
     withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
       spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
-      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 10))
       spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
-      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 5))
     }
   }
 

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -31,8 +31,13 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   import testImplicits._
 
   test("clickhouse command runner") {
+    // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
+    // flipped the default of `output_format_json_quote_64bit_integers` from 1 to 0
+    // around 25.7+, which changes the output from `"4"` to bare `4`.
     checkAnswer(
-      runClickHouseSQL("SELECT visibleWidth(NULL)"),
+      runClickHouseSQL(
+        "SELECT visibleWidth(NULL) SETTINGS output_format_json_quote_64bit_integers=1"
+      ),
       Row("""{"visibleWidth(NULL)":"4"}""") :: Nil
     )
   }

--- a/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.3/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -390,6 +390,65 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     )
   }
 
+  test("push down top N") {
+    val db = "db_topn"
+    // Table name is suffixed with nanoTime so the system.query_log scan below
+    // matches only this run's queries.
+    val tbl = s"tbl_topn_${System.nanoTime()}"
+    // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
+    val schema = StructType(
+      StructField("id", LongType, nullable = false) ::
+        StructField("interval", LongType, nullable = true) :: Nil
+    )
+    withTable(db, tbl, schema) { (actualDb, actualTbl) =>
+      runClickHouseSQL(
+        s"""INSERT INTO `$actualDb`.`$actualTbl` VALUES
+           |  (1, 10),
+           |  (2, 20),
+           |  (3, 30),
+           |  (4, 40),
+           |  (5, NULL)
+           |""".stripMargin
+      ).collect()
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+        Seq(Row(40L), Row(30L))
+      )
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      val recentQueries = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log
+           |WHERE type = 'QueryFinish'
+           |  AND query LIKE '%$actualDb%$actualTbl%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 60 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      ).collect().map(_.getString(0))
+      val pushedTopN = recentQueries.exists { q =>
+        q.contains("ORDER BY `interval` DESC NULLS LAST") && q.contains("LIMIT 2")
+      }
+      assert(
+        pushedTopN,
+        "Pushed query should include 'ORDER BY `interval` DESC NULLS LAST' and 'LIMIT 2'. " +
+          s"Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval ASC NULLS FIRST LIMIT 2"),
+        Seq(Row(null), Row(10L))
+      )
+
+      withSQLConf("spark.clickhouse.read.pushdown.topN" -> "false") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
+    }
+  }
+
   test("push down aggregation") {
     val db = "db_agg_col"
     val tbl = "tbl_agg_col"

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.OrderExpr
+import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
@@ -70,13 +70,13 @@ class ClickHouseScanBuilder(
   private var _orderByClause: Option[String] = None
 
   private def renderOrderExpr(o: OrderExpr): String = {
-    val exprSql = o.expr match {
-      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
-      case other => other.sql
-    }
     val direction = if (o.asc) "ASC" else "DESC"
     val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"$exprSql $direction $nulls"
+    val sql = o.expr match {
+      case FieldRef(name) => Utils.wrapBackQuote(name)
+      case other => other.sql
+    }
+    s"$sql $direction $nulls"
   }
 
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,12 +27,27 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
+import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
+
+object ClickHouseScanBuilder {
+
+  def renderClickHouseSql(expr: Expr): String = expr match {
+    case FieldRef(name) => Utils.wrapBackQuote(name)
+    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
+    case other => other.sql
+  }
+
+  def renderOrderExpr(o: OrderExpr): String = {
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"${renderClickHouseSql(o.expr)} $direction $nulls"
+  }
+}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -69,23 +84,14 @@ class ClickHouseScanBuilder(
 
   private var _orderByClause: Option[String] = None
 
-  private def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    val sql = o.expr match {
-      case FieldRef(name) => Utils.wrapBackQuote(name)
-      case other => other.sql
-    }
-    s"$sql $direction $nulls"
-  }
-
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
     if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
 
     val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o))
     if (translated.exists(_.isEmpty)) return false
 
-    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._orderByClause =
+      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,27 +27,12 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.ExprRender
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
-
-object ClickHouseScanBuilder {
-
-  def renderClickHouseSql(expr: Expr): String = expr match {
-    case FieldRef(name) => Utils.wrapBackQuote(name)
-    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
-    case other => other.sql
-  }
-
-  def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"${renderClickHouseSql(o.expr)} $direction $nulls"
-  }
-}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -91,7 +76,7 @@ class ClickHouseScanBuilder(
     if (translated.exists(_.isEmpty)) return false
 
     this._orderByClause =
-      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+      Some(translated.flatten.map(ExprRender.renderOrder).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -14,9 +14,10 @@
 
 package com.clickhouse.spark.read
 
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
+import org.apache.spark.sql.clickhouse.ExprUtils
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
-import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, SortOrder => V2SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
@@ -26,6 +27,7 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
+import com.clickhouse.spark.expr.OrderExpr
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
@@ -38,12 +40,14 @@ class ClickHouseScanBuilder(
   metadataSchema: StructType,
   partitionTransforms: Array[Transform]
 ) extends ScanBuilder
+    with SupportsPushDownTopN
     with SupportsPushDownLimit
     with SupportsPushDownFilters
     with SupportsPushDownAggregates
     with SupportsPushDownRequiredColumns
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   implicit private val tz: ZoneId = scanJob.tz
@@ -62,6 +66,34 @@ class ClickHouseScanBuilder(
     this._limit = Some(limit)
     true
   }
+
+  private var _orderByClause: Option[String] = None
+
+  private def renderOrderExpr(o: OrderExpr): String = {
+    val exprSql = o.expr match {
+      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
+      case other => other.sql
+    }
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"$exprSql $direction $nulls"
+  }
+
+  override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
+    if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
+
+    val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o))
+    if (translated.exists(_.isEmpty)) return false
+
+    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._limit = Some(limit)
+    true
+  }
+
+  // Each ClickHouse input partition runs its own `ORDER BY ... LIMIT n`, returning a local
+  // top-N. Spark must perform the final global merge across partitions, so we always
+  // report the pushdown as partial.
+  override def isPartiallyPushed: Boolean = true
 
   private var _pushedFilters = Array.empty[Filter]
 
@@ -121,6 +153,7 @@ class ClickHouseScanBuilder(
     readSchema = _readSchema,
     filtersExpr = compileFilters(AlwaysTrue :: pushedFilters.toList),
     groupByClause = _groupByClause,
+    orderByClause = _orderByClause,
     limit = _limit
   ))
 }

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -61,6 +61,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}
        |""".stripMargin

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
@@ -35,6 +35,7 @@ case class ScanJobDescription(
   // into Scan tasks because the check happens in planing phase on driver side.
   filtersExpr: String = "1=1",
   groupByClause: Option[String] = None,
+  orderByClause: Option[String] = None,
   limit: Option[Int] = None
 ) {
 

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -236,7 +236,8 @@ object ClickHouseSQLConf {
       .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
         "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
         "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
-        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+        "input partitions. When `false`, the `ORDER BY ... LIMIT n` is left for Spark to " +
+        "evaluate; plain `LIMIT n` queries (no `ORDER BY`) are unaffected.")
       .version("0.10.1")
       .booleanConf
       .createWithDefault(true)

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -231,4 +231,14 @@ object ClickHouseSQLConf {
       .transform(_.toLowerCase)
       .createOptional
 
+  val READ_PUSHDOWN_TOP_N: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.read.pushdown.topN")
+      .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
+        "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
+        "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
+        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+      .version("0.10.1")
+      .booleanConf
+      .createWithDefault(true)
+
 }

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -110,16 +110,19 @@ object ExprUtils extends SQLConfHelper with Logging {
     case other: Transform => throw CHClientException(s"Unsupported transform: $other")
   }
 
+  // 3.3 has no FunctionRegistry to gate function-transform pushdown safely, so
+  // sort-pushdown is restricted to bare column references - which V2 expresses
+  // either as a top-level NamedReference or as an IdentityTransform wrapping one.
+  // Anything else (function transforms, nested paths, arbitrary scalar exprs)
+  // falls through and is left for Spark to evaluate.
   def toClickHouseSortOrderOpt(sortOrder: SortOrder): Option[OrderExpr] = {
     val asc = sortOrder.direction() == SortDirection.ASCENDING
     val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
     sortOrder.expression() match {
-      // length == 1 restricts to top-level columns and to exclude nested paths.
       case ref: NamedReference if ref.fieldNames().length == 1 =>
         Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
-      case t: Transform =>
-        try Some(OrderExpr(toClickHouse(t), asc, nullFirst))
-        catch { case _: CHClientException => None }
+      case IdentityTransform(FieldReference(Seq(col))) =>
+        Some(OrderExpr(FieldRef(col), asc, nullFirst))
       case _ => None
     }
   }

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -110,6 +110,20 @@ object ExprUtils extends SQLConfHelper with Logging {
     case other: Transform => throw CHClientException(s"Unsupported transform: $other")
   }
 
+  def toClickHouseSortOrderOpt(sortOrder: SortOrder): Option[OrderExpr] = {
+    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
+    sortOrder.expression() match {
+      // length == 1 restricts to top-level columns and to exclude nested paths.
+      case ref: NamedReference if ref.fieldNames().length == 1 =>
+        Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
+      case t: Transform =>
+        try Some(OrderExpr(toClickHouse(t), asc, nullFirst))
+        catch { case _: CHClientException => None }
+      case _ => None
+    }
+  }
+
   def inferTransformSchema(
     primarySchema: StructType,
     secondarySchema: StructType,

--- a/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -111,7 +111,7 @@ object ExprUtils extends SQLConfHelper with Logging {
   }
 
   def toClickHouseSortOrderOpt(sortOrder: SortOrder): Option[OrderExpr] = {
-    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val asc = sortOrder.direction() == SortDirection.ASCENDING
     val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
     sortOrder.expression() match {
       // length == 1 restricts to top-level columns and to exclude nested paths.

--- a/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -15,7 +15,7 @@
 package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
-import com.clickhouse.spark.read.ClickHouseScanBuilder
+import com.clickhouse.spark.expr.ExprRender
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -70,28 +70,28 @@ class ExprUtilsSuite extends AnyFunSuite {
     assert(ExprUtils.toClickHouseSortOrderOpt(sort).isEmpty)
   }
 
-  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
     )
     assert(rendered === "`order` ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: function-transform leaf field is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: function-transform leaf field is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
     )
     assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
     )
     assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
   }
 
-  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under IdentityTransform") {
+  test("toClickHouseSortOrderOpt + renderOrder: end-to-end with reserved-word column under IdentityTransform") {
     val sort = Expressions.sort(
       Expressions.identity("order"),
       SortDirection.ASCENDING,
@@ -99,7 +99,7 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort)
     assert(translated.isDefined)
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "`order` ASC NULLS LAST")
+    assert(ExprRender.renderOrder(translated.get) === "`order` ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: literal expression returns None") {

--- a/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -15,6 +15,7 @@
 package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
+import com.clickhouse.spark.read.ClickHouseScanBuilder
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -57,15 +58,48 @@ class ExprUtilsSuite extends AnyFunSuite {
       Some(OrderExpr(FieldRef("k"), asc = true, nullFirst = false)))
   }
 
-  test("toClickHouseSortOrderOpt: ApplyTransform passes through (no registry in 3.3)") {
+  test("toClickHouseSortOrderOpt: ApplyTransform outside hardcoded allow-list returns None (3.3)") {
+    // 3.3 has no FunctionRegistry, so the sort-pushdown path refuses any
+    // ApplyTransform whose name isn't one of the four hardcoded mappings --
+    // forwarding an arbitrary name would risk emitting SQL the server rejects.
     val sort = Expressions.sort(
       Expressions.apply("xxHash64", Expressions.column("k")),
       SortDirection.ASCENDING,
       NullOrdering.NULLS_LAST
     )
-    assert(ExprUtils.toClickHouseSortOrderOpt(sort) === Some(
-      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
-    ))
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort).isEmpty)
+  }
+
+  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
+    )
+    assert(rendered === "`order` ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: function-transform leaf field is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
+    )
+    assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
+    )
+    assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under IdentityTransform") {
+    val sort = Expressions.sort(
+      Expressions.identity("order"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort)
+    assert(translated.isDefined)
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "`order` ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: literal expression returns None") {

--- a/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse
+
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import org.apache.spark.sql.connector.expressions.{
+  Expressions,
+  GeneralScalarExpression,
+  LiteralValue,
+  NullOrdering,
+  SortDirection
+}
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExprUtilsSuite extends AnyFunSuite {
+
+  test("toClickHouseSortOrderOpt: ASC NULLS FIRST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("id"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_FIRST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort) ===
+      Some(OrderExpr(FieldRef("id"), asc = true, nullFirst = true)))
+  }
+
+  test("toClickHouseSortOrderOpt: DESC NULLS LAST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("ts"),
+      SortDirection.DESCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort) ===
+      Some(OrderExpr(FieldRef("ts"), asc = false, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: identity transform on field") {
+    val sort = Expressions.sort(
+      Expressions.identity("k"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort) ===
+      Some(OrderExpr(FieldRef("k"), asc = true, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: ApplyTransform passes through (no registry in 3.3)") {
+    // In Spark 3.3 ExprUtils.toClickHouse is permissive: any ApplyTransform becomes
+    // a FuncExpr with the same name, regardless of whether the function is registered.
+    val sort = Expressions.sort(
+      Expressions.apply("xxHash64", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort)
+    assert(translated.isDefined)
+    val OrderExpr(expr, asc, nullFirst) = translated.get
+    assert(asc && !nullFirst)
+    assert(expr.asInstanceOf[FuncExpr].name === "xxHash64")
+  }
+
+  test("toClickHouseSortOrderOpt: literal expression returns None") {
+    val sort = Expressions.sort(
+      LiteralValue[Integer](Integer.valueOf(1), IntegerType),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary GeneralScalarExpression returns None") {
+    val sort = Expressions.sort(
+      new GeneralScalarExpression("=", Array(Expressions.column("k"), LiteralValue(1, IntegerType))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort).isEmpty)
+  }
+}

--- a/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -14,7 +14,7 @@
 
 package org.apache.spark.sql.clickhouse
 
-import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -58,18 +58,14 @@ class ExprUtilsSuite extends AnyFunSuite {
   }
 
   test("toClickHouseSortOrderOpt: ApplyTransform passes through (no registry in 3.3)") {
-    // In Spark 3.3 ExprUtils.toClickHouse is permissive: any ApplyTransform becomes
-    // a FuncExpr with the same name, regardless of whether the function is registered.
     val sort = Expressions.sort(
       Expressions.apply("xxHash64", Expressions.column("k")),
       SortDirection.ASCENDING,
       NullOrdering.NULLS_LAST
     )
-    val translated = ExprUtils.toClickHouseSortOrderOpt(sort)
-    assert(translated.isDefined)
-    val OrderExpr(expr, asc, nullFirst) = translated.get
-    assert(asc && !nullFirst)
-    assert(expr.asInstanceOf[FuncExpr].name === "xxHash64")
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort) === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+    ))
   }
 
   test("toClickHouseSortOrderOpt: literal expression returns None") {

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -43,12 +43,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse catalog") {
-    withDatabase("db_t1", "db_t2") {
-      spark.sql("CREATE DATABASE db_t1")
-      spark.sql("CREATE DATABASE db_t2")
+    val prefix = if (useSuiteLevelDatabase) s"${testDatabaseName}_cat" else "db_t"
+    val db1 = s"${prefix}1"
+    val db2 = s"${prefix}2"
+    withDatabase(db1, db2) {
+      spark.sql(s"CREATE DATABASE $db1")
+      spark.sql(s"CREATE DATABASE $db2")
       checkAnswer(
-        spark.sql("SHOW DATABASES LIKE 'db_t*'"),
-        Row("db_t1") :: Row("db_t2") :: Nil
+        spark.sql(s"SHOW DATABASES LIKE '${prefix}*'"),
+        Row(db1) :: Row(db2) :: Nil
       )
       spark.sql("USE system")
       checkAnswer(
@@ -431,9 +434,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      runClickHouseSQL(
+        if (isCloud) "SYSTEM FLUSH LOGS ON CLUSTER 'default'"
+        else "SYSTEM FLUSH LOGS"
+      ).collect()
+      val queryLogRef =
+        if (isCloud) "clusterAllReplicas('default', system, query_log)"
+        else "system.query_log"
       val recentQueries = runClickHouseSQL(
-        s"""SELECT query FROM system.query_log
+        s"""SELECT query FROM $queryLogRef
            |WHERE type = 'QueryFinish'
            |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -68,52 +68,51 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("clickhouse partition") {
     val db = "db_part"
-    val tbl = "tbl_part"
 
     // DROP + PURGE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 1) PURGE")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
 
     // DROP + TRUNCATE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"TRUNCATE TABLE $db.$tbl PARTITION(m = 1)")
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
@@ -253,9 +252,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   // TODO remove this hack version
   test("clickhouse partition toYYYYMMDD(toDate(col))") {
-    val db = "db_part_toYYYYMMDD_toDate"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_part_toYYYYMMDD_toDate"
     val tbl = "tbl_part_toYYYYMMDD_toDate"
-    autoCleanupTable(db, tbl) { case (db, tbl) =>
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       runClickHouseSQL(
         s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl` (
            |    `id` Int64,
@@ -284,7 +284,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(2L, "2022-06-07")
         )
       )
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("clickhouse multi sort columns") {
@@ -324,20 +329,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse truncate table") {
-    withClickHouseSingleIdTable("db_trunc", "tbl_trunc") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"TRUNCATE TABLE $db.$tbl")
-      assert(spark.table(s"$db.$tbl").count == 0)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_trunc", "tbl_trunc", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 0)
     }
   }
 
   test("clickhouse delete") {
-    withClickHouseSingleIdTable("db_del", "tbl_db_del") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"DELETE FROM $db.$tbl WHERE id < 5")
-      assert(spark.table(s"$db.$tbl").count == 5)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
     }
   }
 
@@ -346,7 +353,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val tbl = "tbl_rw"
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       assert(tblSchema == StructType(
         StructField("id", DataTypes.LongType, false) ::
           StructField("value", DataTypes.StringType, true) ::
@@ -355,7 +362,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       ))
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("m"),
+        spark.table(s"$actualDb.$actualTbl").sort("m"),
         Seq(
           Row(1L, "1", timestamp("2021-01-01T10:10:10Z"), 1),
           Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2)
@@ -363,11 +370,11 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.table(s"$db.$tbl").filter($"id" > 1),
+        spark.table(s"$actualDb.$actualTbl").filter($"id" > 1),
         Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2) :: Nil
       )
 
-      assert(spark.table(s"$db.$tbl").filter($"id" > 1).count === 1)
+      assert(spark.table(s"$actualDb.$actualTbl").filter($"id" > 1).count === 1)
 
     // infiniteLoop()
     }
@@ -379,7 +386,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT m, _partition_id FROM $db.$tbl ORDER BY m"),
+        spark.sql(s"SELECT m, _partition_id FROM $actualDb.$actualTbl ORDER BY m"),
         Seq(
           Row(1, "1"),
           Row(2, "2")
@@ -461,22 +468,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT COUNT(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT COUNT(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MIN(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MIN(id) FROM $actualDb.$actualTbl"),
         Seq(Row(1))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MAX(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MAX(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 1)
@@ -484,7 +491,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 2)
@@ -494,7 +501,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("create or replace table") {
-    autoCleanupTable("db_cor", "tbl_cor") { (db, tbl) =>
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_cor"
+    val tbl = "tbl_cor"
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       def createOrReplaceTable(): Unit = spark.sql(
         s"""CREATE OR REPLACE TABLE `$db`.`$tbl` (
            |  id Long NOT NULL
@@ -508,7 +518,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
       createOrReplaceTable()
       createOrReplaceTable()
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("cache table") {
@@ -517,12 +532,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       try {
-        spark.sql(s"CACHE TABLE $db.$tbl")
-        val cachedPlan = spark.sql(s"SELECT * FROM $db.$tbl").queryExecution.commandExecuted
+        spark.sql(s"CACHE TABLE $actualDb.$actualTbl")
+        val cachedPlan = spark.sql(s"SELECT * FROM $actualDb.$actualTbl").queryExecution.commandExecuted
           .find(node => spark.sharedState.cacheManager.lookupCachedData(node).isDefined)
         assert(cachedPlan.isDefined)
       } finally
-        spark.sql(s"UNCACHE TABLE $db.$tbl")
+        spark.sql(s"UNCACHE TABLE $actualDb.$actualTbl")
     }
   }
 
@@ -533,24 +548,24 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=false")
       checkAnswer(
-        spark.sql(s"SELECT id FROM $db.$tbl " +
+        spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
           s"WHERE id IN (" +
-          s"  SELECT id FROM $db.$tbl " +
+          s"  SELECT id FROM $actualDb.$actualTbl " +
           s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
           s")"),
         Row(1)
       )
 
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=true")
-      val df = spark.sql(s"SELECT id FROM $db.$tbl " +
+      val df = spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
         s"WHERE id IN (" +
-        s"  SELECT id FROM $db.$tbl " +
+        s"  SELECT id FROM $actualDb.$actualTbl " +
         s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
         s")")
       checkAnswer(df, Row(1))
       val runtimeFilterExists = df.queryExecution.sparkPlan.exists {
         case BatchScanExec(_, _, runtimeFilters, _, _, table, _, _, _)
-            if table.name() == TableIdentifier(tbl, Some(db)).quotedString
+            if table.name() == TableIdentifier(actualTbl, Some(actualDb)).quotedString
               && runtimeFilters.nonEmpty => true
         case _ => false
       }

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types._
 import org.scalatest.tags.Cloud
 
 @Cloud
-class ClickHouseCloudGenericSuite extends ClickHouseDataTypeSuite with ClickHouseCloudMixIn
+class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
 
-class ClickHouseSingleGenericSuite extends ClickHouseDataTypeSuite with ClickHouseSingleMixIn
+class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHouseSingleMixIn
 
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
@@ -392,8 +392,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("push down top N") {
     val db = "db_topn"
-    // Table name is suffixed with nanoTime so the system.query_log scan below
-    // matches only this run's queries.
+    // Avoid CREATE TABLE collisions across parallel Spark profiles in CI.
     val tbl = s"tbl_topn_${System.nanoTime()}"
     // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
     val schema = StructType(
@@ -411,18 +410,20 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
            |""".stripMargin
       ).collect()
 
-      checkAnswer(
-        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
-        Seq(Row(40L), Row(30L))
-      )
+      // Tag the query so we can pull it from system.query_log by log_comment.
+      val topNLogTag = java.util.UUID.randomUUID().toString
+      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
 
       runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
       val recentQueries = runClickHouseSQL(
         s"""SELECT query FROM system.query_log
            |WHERE type = 'QueryFinish'
-           |  AND query LIKE '%$actualDb%$actualTbl%'
-           |  AND query LIKE '%SELECT%'
-           |  AND event_time > now() - INTERVAL 60 SECOND
+           |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
       ).collect().map(_.getString(0))

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,7 +19,9 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -29,6 +31,11 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
+  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
@@ -74,50 +81,66 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     // DROP + PURGE
     withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
 
     // DROP + TRUNCATE
     withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
   }
 
@@ -345,9 +368,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
     withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
       spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
-      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 10))
       spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
-      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 5))
     }
   }
 

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -31,8 +31,13 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   import testImplicits._
 
   test("clickhouse command runner") {
+    // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
+    // flipped the default of `output_format_json_quote_64bit_integers` from 1 to 0
+    // around 25.7+, which changes the output from `"4"` to bare `4`.
     checkAnswer(
-      runClickHouseSQL("SELECT visibleWidth(NULL)"),
+      runClickHouseSQL(
+        "SELECT visibleWidth(NULL) SETTINGS output_format_json_quote_64bit_integers=1"
+      ),
       Row("""{"visibleWidth(NULL)":"4"}""") :: Nil
     )
   }

--- a/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.4/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -390,6 +390,65 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     )
   }
 
+  test("push down top N") {
+    val db = "db_topn"
+    // Table name is suffixed with nanoTime so the system.query_log scan below
+    // matches only this run's queries.
+    val tbl = s"tbl_topn_${System.nanoTime()}"
+    // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
+    val schema = StructType(
+      StructField("id", LongType, nullable = false) ::
+        StructField("interval", LongType, nullable = true) :: Nil
+    )
+    withTable(db, tbl, schema) { (actualDb, actualTbl) =>
+      runClickHouseSQL(
+        s"""INSERT INTO `$actualDb`.`$actualTbl` VALUES
+           |  (1, 10),
+           |  (2, 20),
+           |  (3, 30),
+           |  (4, 40),
+           |  (5, NULL)
+           |""".stripMargin
+      ).collect()
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+        Seq(Row(40L), Row(30L))
+      )
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      val recentQueries = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log
+           |WHERE type = 'QueryFinish'
+           |  AND query LIKE '%$actualDb%$actualTbl%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 60 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      ).collect().map(_.getString(0))
+      val pushedTopN = recentQueries.exists { q =>
+        q.contains("ORDER BY `interval` DESC NULLS LAST") && q.contains("LIMIT 2")
+      }
+      assert(
+        pushedTopN,
+        "Pushed query should include 'ORDER BY `interval` DESC NULLS LAST' and 'LIMIT 2'. " +
+          s"Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval ASC NULLS FIRST LIMIT 2"),
+        Seq(Row(null), Row(10L))
+      )
+
+      withSQLConf("spark.clickhouse.read.pushdown.topN" -> "false") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
+    }
+  }
+
   test("push down aggregation") {
     val db = "db_agg_col"
     val tbl = "tbl_agg_col"

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -150,7 +150,8 @@ case class ClickHouseTable(
       cluster = cluster,
       localTableSpec = localTableSpec,
       localTableEngineSpec = localTableEngineSpec,
-      readOptions = new ReadOptions(options.asCaseSensitiveMap())
+      readOptions = new ReadOptions(options.asCaseSensitiveMap()),
+      functionRegistry = functionRegistry
     )
     // TODO schema of partitions
     val partTransforms = Array[Transform]()

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.OrderExpr
+import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
@@ -70,13 +70,13 @@ class ClickHouseScanBuilder(
   private var _orderByClause: Option[String] = None
 
   private def renderOrderExpr(o: OrderExpr): String = {
-    val exprSql = o.expr match {
-      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
-      case other => other.sql
-    }
     val direction = if (o.asc) "ASC" else "DESC"
     val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"$exprSql $direction $nulls"
+    val sql = o.expr match {
+      case FieldRef(name) => Utils.wrapBackQuote(name)
+      case other => other.sql
+    }
+    s"$sql $direction $nulls"
   }
 
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,27 +27,12 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.ExprRender
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
-
-object ClickHouseScanBuilder {
-
-  def renderClickHouseSql(expr: Expr): String = expr match {
-    case FieldRef(name) => Utils.wrapBackQuote(name)
-    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
-    case other => other.sql
-  }
-
-  def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"${renderClickHouseSql(o.expr)} $direction $nulls"
-  }
-}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -91,7 +76,7 @@ class ClickHouseScanBuilder(
     if (translated.exists(_.isEmpty)) return false
 
     this._orderByClause =
-      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+      Some(translated.flatten.map(ExprRender.renderOrder).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -27,12 +27,27 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
-import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
+import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
+
+object ClickHouseScanBuilder {
+
+  def renderClickHouseSql(expr: Expr): String = expr match {
+    case FieldRef(name) => Utils.wrapBackQuote(name)
+    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
+    case other => other.sql
+  }
+
+  def renderOrderExpr(o: OrderExpr): String = {
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"${renderClickHouseSql(o.expr)} $direction $nulls"
+  }
+}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -69,23 +84,14 @@ class ClickHouseScanBuilder(
 
   private var _orderByClause: Option[String] = None
 
-  private def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    val sql = o.expr match {
-      case FieldRef(name) => Utils.wrapBackQuote(name)
-      case other => other.sql
-    }
-    s"$sql $direction $nulls"
-  }
-
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
     if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
 
     val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
     if (translated.exists(_.isEmpty)) return false
 
-    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._orderByClause =
+      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -14,9 +14,10 @@
 
 package com.clickhouse.spark.read
 
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
+import org.apache.spark.sql.clickhouse.ExprUtils
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
-import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, SortOrder => V2SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
@@ -26,6 +27,7 @@ import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
 import com.clickhouse.spark.client.NodeClient
 import com.clickhouse.spark.exception.CHClientException
+import com.clickhouse.spark.expr.OrderExpr
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec._
 
@@ -38,12 +40,14 @@ class ClickHouseScanBuilder(
   metadataSchema: StructType,
   partitionTransforms: Array[Transform]
 ) extends ScanBuilder
+    with SupportsPushDownTopN
     with SupportsPushDownLimit
     with SupportsPushDownFilters
     with SupportsPushDownAggregates
     with SupportsPushDownRequiredColumns
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   implicit private val tz: ZoneId = scanJob.tz
@@ -62,6 +66,34 @@ class ClickHouseScanBuilder(
     this._limit = Some(limit)
     true
   }
+
+  private var _orderByClause: Option[String] = None
+
+  private def renderOrderExpr(o: OrderExpr): String = {
+    val exprSql = o.expr match {
+      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
+      case other => other.sql
+    }
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"$exprSql $direction $nulls"
+  }
+
+  override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
+    if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
+
+    val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
+    if (translated.exists(_.isEmpty)) return false
+
+    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._limit = Some(limit)
+    true
+  }
+
+  // Each ClickHouse input partition runs its own `ORDER BY ... LIMIT n`, returning a local
+  // top-N. Spark must perform the final global merge across partitions, so we always
+  // report the pushdown as partial.
+  override def isPartiallyPushed: Boolean = true
 
   private var _pushedFilters = Array.empty[Filter]
 
@@ -121,6 +153,7 @@ class ClickHouseScanBuilder(
     readSchema = _readSchema,
     filtersExpr = compileFilters(AlwaysTrue :: pushedFilters.toList),
     groupByClause = _groupByClause,
+    orderByClause = _orderByClause,
     limit = _limit
   ))
 }

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -61,6 +61,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}
        |""".stripMargin

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
@@ -14,6 +14,7 @@
 
 package com.clickhouse.spark.read
 
+import com.clickhouse.spark.func.FunctionRegistry
 import org.apache.spark.sql.clickhouse.ReadOptions
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark.spec._
@@ -29,12 +30,14 @@ case class ScanJobDescription(
   localTableSpec: Option[TableSpec],
   localTableEngineSpec: Option[TableEngineSpec],
   readOptions: ReadOptions,
+  functionRegistry: FunctionRegistry,
   // Below fields will be constructed in ScanBuilder.
   readSchema: StructType = new StructType,
   // We should pass compiled ClickHouse SQL snippets(or ClickHouse SQL AST data structure) instead of Spark Expression
   // into Scan tasks because the check happens in planing phase on driver side.
   filtersExpr: String = "1=1",
   groupByClause: Option[String] = None,
+  orderByClause: Option[String] = None,
   limit: Option[Int] = None
 ) {
 

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -236,7 +236,8 @@ object ClickHouseSQLConf {
       .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
         "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
         "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
-        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+        "input partitions. When `false`, the `ORDER BY ... LIMIT n` is left for Spark to " +
+        "evaluate; plain `LIMIT n` queries (no `ORDER BY`) are unaffected.")
       .version("0.10.1")
       .booleanConf
       .createWithDefault(true)

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -231,4 +231,14 @@ object ClickHouseSQLConf {
       .transform(_.toLowerCase)
       .createOptional
 
+  val READ_PUSHDOWN_TOP_N: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.read.pushdown.topN")
+      .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
+        "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
+        "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
+        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+      .version("0.10.1")
+      .booleanConf
+      .createWithDefault(true)
+
 }

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -213,10 +213,31 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
       case ref: NamedReference if ref.fieldNames().length == 1 =>
         Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
       case t: Transform =>
-        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
-        catch { case _: CHClientException => None }
+        toClickHouseSortTransformOpt(t, functionRegistry).map(OrderExpr(_, asc, nullFirst))
       case _ => None
     }
+  }
+
+  private def toClickHouseSortTransformOpt(
+    transform: Transform,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = transform match {
+    case IdentityTransform(FieldReference(Seq(col))) => Some(FieldRef(col))
+    case ApplyTransform(name, args) if functionRegistry.sparkToClickHouseFunc.contains(name) =>
+      val translatedArgs = args.toList.map(toClickHouseSortArgOpt(_, functionRegistry))
+      if (translatedArgs.exists(_.isEmpty)) None
+      else Some(FuncExpr(functionRegistry.sparkToClickHouseFunc(name), translatedArgs.flatten))
+    case _ => None
+  }
+
+  private def toClickHouseSortArgOpt(
+    arg: V2Expression,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = arg match {
+    case ref: NamedReference if ref.fieldNames().length == 1 => Some(FieldRef(ref.fieldNames().head))
+    case t: Transform => toClickHouseSortTransformOpt(t, functionRegistry)
+    case lit: LiteralValue[_] => Some(SQLExpr(lit.describe))
+    case _ => None
   }
 
   def inferTransformSchema(

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -206,7 +206,7 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     sortOrder: V2SortOrder,
     functionRegistry: FunctionRegistry
   ): Option[OrderExpr] = {
-    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val asc = sortOrder.direction() == SortDirection.ASCENDING
     val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
     sortOrder.expression() match {
       // length == 1 restricts to top-level columns and to exclude nested paths.

--- a/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -202,6 +202,23 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     case other: Transform => throw CHClientException(s"Unsupported transform: $other")
   }
 
+  def toClickHouseSortOrderOpt(
+    sortOrder: V2SortOrder,
+    functionRegistry: FunctionRegistry
+  ): Option[OrderExpr] = {
+    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
+    sortOrder.expression() match {
+      // length == 1 restricts to top-level columns and to exclude nested paths.
+      case ref: NamedReference if ref.fieldNames().length == 1 =>
+        Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
+      case t: Transform =>
+        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
+        catch { case _: CHClientException => None }
+      case _ => None
+    }
+  }
+
   def inferTransformSchema(
     primarySchema: StructType,
     secondarySchema: StructType,

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,6 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import com.clickhouse.spark.read.ClickHouseScanBuilder
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -72,8 +73,40 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated === Some(
-      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("k"))), asc = true, nullFirst = false)
     ))
+  }
+
+  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
+    )
+    assert(rendered === "`order` ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: function-transform leaf field is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
+    )
+    assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
+    )
+    assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("order")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -101,5 +134,56 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: nested function transform recurses and back-quotes leaf") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("ck_xx_hash64", Expressions.column("order"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(
+        FuncExpr("xxHash64", List(FuncExpr("xxHash64", List(FieldRef("order"))))),
+        asc = true,
+        nullFirst = false
+      )
+    ))
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+      "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt: literal arg inside function transform is preserved") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", LiteralValue(42, IntegerType)),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("42"))), asc = true, nullFirst = false)
+    ))
+  }
+
+  test("toClickHouseSortOrderOpt: nested unregistered function transform returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("totally_unknown_func", Expressions.column("k"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary V2 expression as function arg returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply(
+        "ck_xx_hash64",
+        new GeneralScalarExpression("+", Array(Expressions.column("k"), LiteralValue(1, IntegerType)))
+      ),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
   }
 }

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -14,7 +14,7 @@
 
 package org.apache.spark.sql.clickhouse
 
-import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
@@ -71,11 +71,9 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
-    assert(translated.isDefined)
-    val OrderExpr(expr, asc, nullFirst) = translated.get
-    assert(asc && !nullFirst)
-    val funcExpr = expr.asInstanceOf[FuncExpr]
-    assert(funcExpr.name === "xxHash64")
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+    ))
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse
+
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import org.apache.spark.sql.connector.expressions.{
+  Expressions,
+  GeneralScalarExpression,
+  LiteralValue,
+  NullOrdering,
+  SortDirection
+}
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExprUtilsSuite extends AnyFunSuite {
+
+  private val registry = {
+    val r = new DynamicFunctionRegistry
+    r.register("ck_xx_hash64", ClickHouseXxHash64)
+    r
+  }
+
+  test("toClickHouseSortOrderOpt: ASC NULLS FIRST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("id"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_FIRST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("id"), asc = true, nullFirst = true)))
+  }
+
+  test("toClickHouseSortOrderOpt: DESC NULLS LAST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("ts"),
+      SortDirection.DESCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("ts"), asc = false, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: identity transform on field") {
+    val sort = Expressions.sort(
+      Expressions.identity("k"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("k"), asc = true, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: function transform registered in registry") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    val OrderExpr(expr, asc, nullFirst) = translated.get
+    assert(asc && !nullFirst)
+    val funcExpr = expr.asInstanceOf[FuncExpr]
+    assert(funcExpr.name === "xxHash64")
+  }
+
+  test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("totally_unknown_func", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: literal expression returns None") {
+    val sort = Expressions.sort(
+      LiteralValue[Integer](Integer.valueOf(1), IntegerType),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary GeneralScalarExpression returns None") {
+    val sort = Expressions.sort(
+      new GeneralScalarExpression("=", Array(Expressions.column("k"), LiteralValue(1, IntegerType))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+}

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
-import com.clickhouse.spark.read.ClickHouseScanBuilder
+import com.clickhouse.spark.expr.ExprRender
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -77,28 +77,28 @@ class ExprUtilsSuite extends AnyFunSuite {
     ))
   }
 
-  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
     )
     assert(rendered === "`order` ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: function-transform leaf field is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: function-transform leaf field is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
     )
     assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
     )
     assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
   }
 
-  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+  test("toClickHouseSortOrderOpt + renderOrder: end-to-end with reserved-word column under xxHash64") {
     val sort = Expressions.sort(
       Expressions.apply("ck_xx_hash64", Expressions.column("order")),
       SortDirection.ASCENDING,
@@ -106,7 +106,7 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated.isDefined)
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
+    assert(ExprRender.renderOrder(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -150,7 +150,7 @@ class ExprUtilsSuite extends AnyFunSuite {
         nullFirst = false
       )
     ))
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+    assert(ExprRender.renderOrder(translated.get) ===
       "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
   }
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -43,12 +43,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse catalog") {
-    withDatabase("db_t1", "db_t2") {
-      spark.sql("CREATE DATABASE db_t1")
-      spark.sql("CREATE DATABASE db_t2")
+    val prefix = if (useSuiteLevelDatabase) s"${testDatabaseName}_cat" else "db_t"
+    val db1 = s"${prefix}1"
+    val db2 = s"${prefix}2"
+    withDatabase(db1, db2) {
+      spark.sql(s"CREATE DATABASE $db1")
+      spark.sql(s"CREATE DATABASE $db2")
       checkAnswer(
-        spark.sql("SHOW DATABASES LIKE 'db_t*'"),
-        Row("db_t1") :: Row("db_t2") :: Nil
+        spark.sql(s"SHOW DATABASES LIKE '${prefix}*'"),
+        Row(db1) :: Row(db2) :: Nil
       )
       spark.sql("USE system")
       checkAnswer(
@@ -431,9 +434,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      runClickHouseSQL(
+        if (isCloud) "SYSTEM FLUSH LOGS ON CLUSTER 'default'"
+        else "SYSTEM FLUSH LOGS"
+      ).collect()
+      val queryLogRef =
+        if (isCloud) "clusterAllReplicas('default', system, query_log)"
+        else "system.query_log"
       val recentQueries = runClickHouseSQL(
-        s"""SELECT query FROM system.query_log
+        s"""SELECT query FROM $queryLogRef
            |WHERE type = 'QueryFinish'
            |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types._
 import org.scalatest.tags.Cloud
 
 @Cloud
-class ClickHouseCloudGenericSuite extends ClickHouseDataTypeSuite with ClickHouseCloudMixIn
+class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
 
-class ClickHouseSingleGenericSuite extends ClickHouseDataTypeSuite with ClickHouseSingleMixIn
+class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHouseSingleMixIn
 
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
@@ -392,8 +392,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("push down top N") {
     val db = "db_topn"
-    // Table name is suffixed with nanoTime so the system.query_log scan below
-    // matches only this run's queries.
+    // Avoid CREATE TABLE collisions across parallel Spark profiles in CI.
     val tbl = s"tbl_topn_${System.nanoTime()}"
     // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
     val schema = StructType(
@@ -411,18 +410,20 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
            |""".stripMargin
       ).collect()
 
-      checkAnswer(
-        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
-        Seq(Row(40L), Row(30L))
-      )
+      // Tag the query so we can pull it from system.query_log by log_comment.
+      val topNLogTag = java.util.UUID.randomUUID().toString
+      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
 
       runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
       val recentQueries = runClickHouseSQL(
         s"""SELECT query FROM system.query_log
            |WHERE type = 'QueryFinish'
-           |  AND query LIKE '%$actualDb%$actualTbl%'
-           |  AND query LIKE '%SELECT%'
-           |  AND event_time > now() - INTERVAL 60 SECOND
+           |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
       ).collect().map(_.getString(0))

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,7 +19,9 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -29,6 +31,11 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
+  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
@@ -74,50 +81,66 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     // DROP + PURGE
     withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
 
     // DROP + TRUNCATE
     withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
   }
 
@@ -345,9 +368,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
     withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
       spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
-      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 10))
       spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
-      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 5))
     }
   }
 

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -68,52 +68,51 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("clickhouse partition") {
     val db = "db_part"
-    val tbl = "tbl_part"
 
     // DROP + PURGE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 1) PURGE")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
 
     // DROP + TRUNCATE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"TRUNCATE TABLE $db.$tbl PARTITION(m = 1)")
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
@@ -253,9 +252,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   // TODO remove this hack version
   test("clickhouse partition toYYYYMMDD(toDate(col))") {
-    val db = "db_part_toYYYYMMDD_toDate"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_part_toYYYYMMDD_toDate"
     val tbl = "tbl_part_toYYYYMMDD_toDate"
-    autoCleanupTable(db, tbl) { case (db, tbl) =>
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       runClickHouseSQL(
         s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl` (
            |    `id` Int64,
@@ -284,7 +284,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(2L, "2022-06-07")
         )
       )
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("clickhouse multi sort columns") {
@@ -324,20 +329,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse truncate table") {
-    withClickHouseSingleIdTable("db_trunc", "tbl_trunc") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"TRUNCATE TABLE $db.$tbl")
-      assert(spark.table(s"$db.$tbl").count == 0)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_trunc", "tbl_trunc", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 0)
     }
   }
 
   test("clickhouse delete") {
-    withClickHouseSingleIdTable("db_del", "tbl_db_del") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"DELETE FROM $db.$tbl WHERE id < 5")
-      assert(spark.table(s"$db.$tbl").count == 5)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
     }
   }
 
@@ -346,7 +353,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val tbl = "tbl_rw"
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       assert(tblSchema == StructType(
         StructField("id", DataTypes.LongType, false) ::
           StructField("value", DataTypes.StringType, true) ::
@@ -355,7 +362,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       ))
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("m"),
+        spark.table(s"$actualDb.$actualTbl").sort("m"),
         Seq(
           Row(1L, "1", timestamp("2021-01-01T10:10:10Z"), 1),
           Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2)
@@ -363,11 +370,11 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.table(s"$db.$tbl").filter($"id" > 1),
+        spark.table(s"$actualDb.$actualTbl").filter($"id" > 1),
         Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2) :: Nil
       )
 
-      assert(spark.table(s"$db.$tbl").filter($"id" > 1).count === 1)
+      assert(spark.table(s"$actualDb.$actualTbl").filter($"id" > 1).count === 1)
 
     // infiniteLoop()
     }
@@ -379,7 +386,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT m, _partition_id FROM $db.$tbl ORDER BY m"),
+        spark.sql(s"SELECT m, _partition_id FROM $actualDb.$actualTbl ORDER BY m"),
         Seq(
           Row(1, "1"),
           Row(2, "2")
@@ -461,22 +468,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT COUNT(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT COUNT(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MIN(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MIN(id) FROM $actualDb.$actualTbl"),
         Seq(Row(1))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MAX(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MAX(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 1)
@@ -484,7 +491,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 2)
@@ -494,7 +501,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("create or replace table") {
-    autoCleanupTable("db_cor", "tbl_cor") { (db, tbl) =>
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_cor"
+    val tbl = "tbl_cor"
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       def createOrReplaceTable(): Unit = spark.sql(
         s"""CREATE OR REPLACE TABLE `$db`.`$tbl` (
            |  id Long NOT NULL
@@ -508,7 +518,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
       createOrReplaceTable()
       createOrReplaceTable()
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("cache table") {
@@ -517,12 +532,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       try {
-        spark.sql(s"CACHE TABLE $db.$tbl")
-        val cachedPlan = spark.sql(s"SELECT * FROM $db.$tbl").queryExecution.commandExecuted
+        spark.sql(s"CACHE TABLE $actualDb.$actualTbl")
+        val cachedPlan = spark.sql(s"SELECT * FROM $actualDb.$actualTbl").queryExecution.commandExecuted
           .find(node => spark.sharedState.cacheManager.lookupCachedData(node).isDefined)
         assert(cachedPlan.isDefined)
       } finally
-        spark.sql(s"UNCACHE TABLE $db.$tbl")
+        spark.sql(s"UNCACHE TABLE $actualDb.$actualTbl")
     }
   }
 
@@ -533,24 +548,24 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=false")
       checkAnswer(
-        spark.sql(s"SELECT id FROM $db.$tbl " +
+        spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
           s"WHERE id IN (" +
-          s"  SELECT id FROM $db.$tbl " +
+          s"  SELECT id FROM $actualDb.$actualTbl " +
           s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
           s")"),
         Row(1)
       )
 
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=true")
-      val df = spark.sql(s"SELECT id FROM $db.$tbl " +
+      val df = spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
         s"WHERE id IN (" +
-        s"  SELECT id FROM $db.$tbl " +
+        s"  SELECT id FROM $actualDb.$actualTbl " +
         s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
         s")")
       checkAnswer(df, Row(1))
       val runtimeFilterExists = df.queryExecution.sparkPlan.exists {
         case BatchScanExec(_, _, runtimeFilters, _, table, _)
-            if table.name() == TableIdentifier(tbl, Some(db)).quotedString
+            if table.name() == TableIdentifier(actualTbl, Some(actualDb)).quotedString
               && runtimeFilters.nonEmpty => true
         case _ => false
       }

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -31,8 +31,13 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   import testImplicits._
 
   test("clickhouse command runner") {
+    // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
+    // flipped the default of `output_format_json_quote_64bit_integers` from 1 to 0
+    // around 25.7+, which changes the output from `"4"` to bare `4`.
     checkAnswer(
-      runClickHouseSQL("SELECT visibleWidth(NULL)"),
+      runClickHouseSQL(
+        "SELECT visibleWidth(NULL) SETTINGS output_format_json_quote_64bit_integers=1"
+      ),
       Row("""{"visibleWidth(NULL)":"4"}""") :: Nil
     )
   }

--- a/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-3.5/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -390,6 +390,65 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     )
   }
 
+  test("push down top N") {
+    val db = "db_topn"
+    // Table name is suffixed with nanoTime so the system.query_log scan below
+    // matches only this run's queries.
+    val tbl = s"tbl_topn_${System.nanoTime()}"
+    // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
+    val schema = StructType(
+      StructField("id", LongType, nullable = false) ::
+        StructField("interval", LongType, nullable = true) :: Nil
+    )
+    withTable(db, tbl, schema) { (actualDb, actualTbl) =>
+      runClickHouseSQL(
+        s"""INSERT INTO `$actualDb`.`$actualTbl` VALUES
+           |  (1, 10),
+           |  (2, 20),
+           |  (3, 30),
+           |  (4, 40),
+           |  (5, NULL)
+           |""".stripMargin
+      ).collect()
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+        Seq(Row(40L), Row(30L))
+      )
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      val recentQueries = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log
+           |WHERE type = 'QueryFinish'
+           |  AND query LIKE '%$actualDb%$actualTbl%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 60 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      ).collect().map(_.getString(0))
+      val pushedTopN = recentQueries.exists { q =>
+        q.contains("ORDER BY `interval` DESC NULLS LAST") && q.contains("LIMIT 2")
+      }
+      assert(
+        pushedTopN,
+        "Pushed query should include 'ORDER BY `interval` DESC NULLS LAST' and 'LIMIT 2'. " +
+          s"Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval ASC NULLS FIRST LIMIT 2"),
+        Seq(Row(null), Row(10L))
+      )
+
+      withSQLConf("spark.clickhouse.read.pushdown.topN" -> "false") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
+    }
+  }
+
   test("push down aggregation") {
     val db = "db_agg_col"
     val tbl = "tbl_agg_col"

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -160,7 +160,8 @@ case class ClickHouseTable(
       cluster = cluster,
       localTableSpec = localTableSpec,
       localTableEngineSpec = localTableEngineSpec,
-      readOptions = new ReadOptions(options.asCaseSensitiveMap())
+      readOptions = new ReadOptions(options.asCaseSensitiveMap()),
+      functionRegistry = functionRegistry
     )
     // TODO schema of partitions
     val partTransforms = Array[Transform]()

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -19,9 +19,10 @@ import com.clickhouse.spark.exception.CHClientException
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, TableEngineSpec}
 import com.clickhouse.spark.{BlocksReadMetric, BytesReadMetric, ClickHouseHelper, Logging, SQLHelper, Utils}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
+import org.apache.spark.sql.clickhouse.ExprUtils
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
-import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, SortOrder => V2SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
@@ -29,6 +30,7 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
+import com.clickhouse.spark.expr.OrderExpr
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
@@ -40,12 +42,14 @@ class ClickHouseScanBuilder(
   metadataSchema: StructType,
   partitionTransforms: Array[Transform]
 ) extends ScanBuilder
+    with SupportsPushDownTopN
     with SupportsPushDownLimit
     with SupportsPushDownFilters
     with SupportsPushDownAggregates
     with SupportsPushDownRequiredColumns
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   implicit private val tz: ZoneId = scanJob.tz
@@ -64,6 +68,34 @@ class ClickHouseScanBuilder(
     this._limit = Some(limit)
     true
   }
+
+  private var _orderByClause: Option[String] = None
+
+  private def renderOrderExpr(o: OrderExpr): String = {
+    val exprSql = o.expr match {
+      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
+      case other => other.sql
+    }
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"$exprSql $direction $nulls"
+  }
+
+  override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
+    if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
+
+    val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
+    if (translated.exists(_.isEmpty)) return false
+
+    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._limit = Some(limit)
+    true
+  }
+
+  // Each ClickHouse input partition runs its own `ORDER BY ... LIMIT n`, returning a local
+  // top-N. Spark must perform the final global merge across partitions, so we always
+  // report the pushdown as partial.
+  override def isPartiallyPushed: Boolean = true
 
   private var _pushedFilters = Array.empty[Filter]
 
@@ -123,6 +155,7 @@ class ClickHouseScanBuilder(
     readSchema = _readSchema,
     filtersExpr = compileFilters(AlwaysTrue :: pushedFilters.toList),
     groupByClause = _groupByClause,
+    orderByClause = _orderByClause,
     limit = _limit
   ))
 }

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.OrderExpr
+import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
@@ -72,13 +72,13 @@ class ClickHouseScanBuilder(
   private var _orderByClause: Option[String] = None
 
   private def renderOrderExpr(o: OrderExpr): String = {
-    val exprSql = o.expr match {
-      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
-      case other => other.sql
-    }
     val direction = if (o.asc) "ASC" else "DESC"
     val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"$exprSql $direction $nulls"
+    val sql = o.expr match {
+      case FieldRef(name) => Utils.wrapBackQuote(name)
+      case other => other.sql
+    }
+    s"$sql $direction $nulls"
   }
 
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,26 +30,11 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.ExprRender
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
-
-object ClickHouseScanBuilder {
-
-  def renderClickHouseSql(expr: Expr): String = expr match {
-    case FieldRef(name) => Utils.wrapBackQuote(name)
-    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
-    case other => other.sql
-  }
-
-  def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"${renderClickHouseSql(o.expr)} $direction $nulls"
-  }
-}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -93,7 +78,7 @@ class ClickHouseScanBuilder(
     if (translated.exists(_.isEmpty)) return false
 
     this._orderByClause =
-      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+      Some(translated.flatten.map(ExprRender.renderOrder).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,11 +30,26 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
+import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
+
+object ClickHouseScanBuilder {
+
+  def renderClickHouseSql(expr: Expr): String = expr match {
+    case FieldRef(name) => Utils.wrapBackQuote(name)
+    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
+    case other => other.sql
+  }
+
+  def renderOrderExpr(o: OrderExpr): String = {
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"${renderClickHouseSql(o.expr)} $direction $nulls"
+  }
+}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -71,23 +86,14 @@ class ClickHouseScanBuilder(
 
   private var _orderByClause: Option[String] = None
 
-  private def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    val sql = o.expr match {
-      case FieldRef(name) => Utils.wrapBackQuote(name)
-      case other => other.sql
-    }
-    s"$sql $direction $nulls"
-  }
-
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
     if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
 
     val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
     if (translated.exists(_.isEmpty)) return false
 
-    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._orderByClause =
+      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -60,6 +60,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}
        |""".stripMargin

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
@@ -14,6 +14,7 @@
 
 package com.clickhouse.spark.read
 
+import com.clickhouse.spark.func.FunctionRegistry
 import com.clickhouse.spark.spec.{ClusterSpec, DistributedEngineSpec, NodeSpec, TableEngineSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ReadOptions
 import org.apache.spark.sql.types.StructType
@@ -29,12 +30,14 @@ case class ScanJobDescription(
   localTableSpec: Option[TableSpec],
   localTableEngineSpec: Option[TableEngineSpec],
   readOptions: ReadOptions,
+  functionRegistry: FunctionRegistry,
   // Below fields will be constructed in ScanBuilder.
   readSchema: StructType = new StructType,
   // We should pass compiled ClickHouse SQL snippets(or ClickHouse SQL AST data structure) instead of Spark Expression
   // into Scan tasks because the check happens in planing phase on driver side.
   filtersExpr: String = "1=1",
   groupByClause: Option[String] = None,
+  orderByClause: Option[String] = None,
   limit: Option[Int] = None
 ) {
 

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -236,7 +236,8 @@ object ClickHouseSQLConf {
       .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
         "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
         "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
-        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+        "input partitions. When `false`, the `ORDER BY ... LIMIT n` is left for Spark to " +
+        "evaluate; plain `LIMIT n` queries (no `ORDER BY`) are unaffected.")
       .version("0.10.1")
       .booleanConf
       .createWithDefault(true)

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -231,4 +231,14 @@ object ClickHouseSQLConf {
       .transform(_.toLowerCase)
       .createOptional
 
+  val READ_PUSHDOWN_TOP_N: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.read.pushdown.topN")
+      .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
+        "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
+        "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
+        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+      .version("0.10.1")
+      .booleanConf
+      .createWithDefault(true)
+
 }

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -214,10 +214,31 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
       case ref: NamedReference if ref.fieldNames().length == 1 =>
         Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
       case t: Transform =>
-        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
-        catch { case _: CHClientException => None }
+        toClickHouseSortTransformOpt(t, functionRegistry).map(OrderExpr(_, asc, nullFirst))
       case _ => None
     }
+  }
+
+  private def toClickHouseSortTransformOpt(
+    transform: Transform,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = transform match {
+    case IdentityTransform(FieldReference(Seq(col))) => Some(FieldRef(col))
+    case ApplyTransform(name, args) if functionRegistry.sparkToClickHouseFunc.contains(name) =>
+      val translatedArgs = args.toList.map(toClickHouseSortArgOpt(_, functionRegistry))
+      if (translatedArgs.exists(_.isEmpty)) None
+      else Some(FuncExpr(functionRegistry.sparkToClickHouseFunc(name), translatedArgs.flatten))
+    case _ => None
+  }
+
+  private def toClickHouseSortArgOpt(
+    arg: V2Expression,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = arg match {
+    case ref: NamedReference if ref.fieldNames().length == 1 => Some(FieldRef(ref.fieldNames().head))
+    case t: Transform => toClickHouseSortTransformOpt(t, functionRegistry)
+    case lit: LiteralValue[_] => Some(SQLExpr(lit.describe))
+    case _ => None
   }
 
   def inferTransformSchema(

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -203,6 +203,23 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     case other: Transform => throw CHClientException(s"Unsupported transform: $other")
   }
 
+  def toClickHouseSortOrderOpt(
+    sortOrder: V2SortOrder,
+    functionRegistry: FunctionRegistry
+  ): Option[OrderExpr] = {
+    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
+    sortOrder.expression() match {
+      // length == 1 restricts to top-level columns and to exclude nested paths.
+      case ref: NamedReference if ref.fieldNames().length == 1 =>
+        Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
+      case t: Transform =>
+        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
+        catch { case _: CHClientException => None }
+      case _ => None
+    }
+  }
+
   def inferTransformSchema(
     primarySchema: StructType,
     secondarySchema: StructType,

--- a/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -207,7 +207,7 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     sortOrder: V2SortOrder,
     functionRegistry: FunctionRegistry
   ): Option[OrderExpr] = {
-    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val asc = sortOrder.direction() == SortDirection.ASCENDING
     val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
     sortOrder.expression() match {
       // length == 1 restricts to top-level columns and to exclude nested paths.

--- a/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,6 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import com.clickhouse.spark.read.ClickHouseScanBuilder
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -72,8 +73,40 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated === Some(
-      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("k"))), asc = true, nullFirst = false)
     ))
+  }
+
+  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
+    )
+    assert(rendered === "`order` ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: function-transform leaf field is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
+    )
+    assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
+    )
+    assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("order")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -101,5 +134,56 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: nested function transform recurses and back-quotes leaf") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("ck_xx_hash64", Expressions.column("order"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(
+        FuncExpr("xxHash64", List(FuncExpr("xxHash64", List(FieldRef("order"))))),
+        asc = true,
+        nullFirst = false
+      )
+    ))
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+      "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt: literal arg inside function transform is preserved") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", LiteralValue(42, IntegerType)),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("42"))), asc = true, nullFirst = false)
+    ))
+  }
+
+  test("toClickHouseSortOrderOpt: nested unregistered function transform returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("totally_unknown_func", Expressions.column("k"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary V2 expression as function arg returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply(
+        "ck_xx_hash64",
+        new GeneralScalarExpression("+", Array(Expressions.column("k"), LiteralValue(1, IntegerType)))
+      ),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
   }
 }

--- a/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -14,7 +14,7 @@
 
 package org.apache.spark.sql.clickhouse
 
-import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
@@ -71,11 +71,9 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
-    assert(translated.isDefined)
-    val OrderExpr(expr, asc, nullFirst) = translated.get
-    assert(asc && !nullFirst)
-    val funcExpr = expr.asInstanceOf[FuncExpr]
-    assert(funcExpr.name === "xxHash64")
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+    ))
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {

--- a/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse
+
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import org.apache.spark.sql.connector.expressions.{
+  Expressions,
+  GeneralScalarExpression,
+  LiteralValue,
+  NullOrdering,
+  SortDirection
+}
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExprUtilsSuite extends AnyFunSuite {
+
+  private val registry = {
+    val r = new DynamicFunctionRegistry
+    r.register("ck_xx_hash64", ClickHouseXxHash64)
+    r
+  }
+
+  test("toClickHouseSortOrderOpt: ASC NULLS FIRST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("id"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_FIRST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("id"), asc = true, nullFirst = true)))
+  }
+
+  test("toClickHouseSortOrderOpt: DESC NULLS LAST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("ts"),
+      SortDirection.DESCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("ts"), asc = false, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: identity transform on field") {
+    val sort = Expressions.sort(
+      Expressions.identity("k"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("k"), asc = true, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: function transform registered in registry") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    val OrderExpr(expr, asc, nullFirst) = translated.get
+    assert(asc && !nullFirst)
+    val funcExpr = expr.asInstanceOf[FuncExpr]
+    assert(funcExpr.name === "xxHash64")
+  }
+
+  test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("totally_unknown_func", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: literal expression returns None") {
+    val sort = Expressions.sort(
+      LiteralValue[Integer](Integer.valueOf(1), IntegerType),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary GeneralScalarExpression returns None") {
+    val sort = Expressions.sort(
+      new GeneralScalarExpression("=", Array(Expressions.column("k"), LiteralValue(1, IntegerType))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+}

--- a/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
-import com.clickhouse.spark.read.ClickHouseScanBuilder
+import com.clickhouse.spark.expr.ExprRender
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -77,28 +77,28 @@ class ExprUtilsSuite extends AnyFunSuite {
     ))
   }
 
-  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
     )
     assert(rendered === "`order` ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: function-transform leaf field is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: function-transform leaf field is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
     )
     assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
     )
     assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
   }
 
-  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+  test("toClickHouseSortOrderOpt + renderOrder: end-to-end with reserved-word column under xxHash64") {
     val sort = Expressions.sort(
       Expressions.apply("ck_xx_hash64", Expressions.column("order")),
       SortDirection.ASCENDING,
@@ -106,7 +106,7 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated.isDefined)
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
+    assert(ExprRender.renderOrder(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -150,7 +150,7 @@ class ExprUtilsSuite extends AnyFunSuite {
         nullFirst = false
       )
     ))
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+    assert(ExprRender.renderOrder(translated.get) ===
       "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
   }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -43,12 +43,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse catalog") {
-    withDatabase("db_t1", "db_t2") {
-      spark.sql("CREATE DATABASE db_t1")
-      spark.sql("CREATE DATABASE db_t2")
+    val prefix = if (useSuiteLevelDatabase) s"${testDatabaseName}_cat" else "db_t"
+    val db1 = s"${prefix}1"
+    val db2 = s"${prefix}2"
+    withDatabase(db1, db2) {
+      spark.sql(s"CREATE DATABASE $db1")
+      spark.sql(s"CREATE DATABASE $db2")
       checkAnswer(
-        spark.sql("SHOW DATABASES LIKE 'db_t*'"),
-        Row("db_t1") :: Row("db_t2") :: Nil
+        spark.sql(s"SHOW DATABASES LIKE '${prefix}*'"),
+        Row(db1) :: Row(db2) :: Nil
       )
       spark.sql("USE system")
       checkAnswer(
@@ -431,9 +434,15 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
         )
       }
 
-      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      runClickHouseSQL(
+        if (isCloud) "SYSTEM FLUSH LOGS ON CLUSTER 'default'"
+        else "SYSTEM FLUSH LOGS"
+      ).collect()
+      val queryLogRef =
+        if (isCloud) "clusterAllReplicas('default', system, query_log)"
+        else "system.query_log"
       val recentQueries = runClickHouseSQL(
-        s"""SELECT query FROM system.query_log
+        s"""SELECT query FROM $queryLogRef
            |WHERE type = 'QueryFinish'
            |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types._
 import org.scalatest.tags.Cloud
 
 @Cloud
-class ClickHouseCloudGenericSuite extends ClickHouseDataTypeSuite with ClickHouseCloudMixIn
+class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
 
-class ClickHouseSingleGenericSuite extends ClickHouseDataTypeSuite with ClickHouseSingleMixIn
+class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHouseSingleMixIn
 
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
@@ -392,8 +392,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("push down top N") {
     val db = "db_topn"
-    // Table name is suffixed with nanoTime so the system.query_log scan below
-    // matches only this run's queries.
+    // Avoid CREATE TABLE collisions across parallel Spark profiles in CI.
     val tbl = s"tbl_topn_${System.nanoTime()}"
     // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
     val schema = StructType(
@@ -411,18 +410,20 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
            |""".stripMargin
       ).collect()
 
-      checkAnswer(
-        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
-        Seq(Row(40L), Row(30L))
-      )
+      // Tag the query so we can pull it from system.query_log by log_comment.
+      val topNLogTag = java.util.UUID.randomUUID().toString
+      withSQLConf("spark.clickhouse.read.settings" -> s"log_comment='$topNLogTag'") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
 
       runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
       val recentQueries = runClickHouseSQL(
         s"""SELECT query FROM system.query_log
            |WHERE type = 'QueryFinish'
-           |  AND query LIKE '%$actualDb%$actualTbl%'
-           |  AND query LIKE '%SELECT%'
-           |  AND event_time > now() - INTERVAL 60 SECOND
+           |  AND log_comment = '$topNLogTag'
            |ORDER BY event_time DESC
            |LIMIT 5""".stripMargin
       ).collect().map(_.getString(0))

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -19,7 +19,9 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.types._
+import org.scalatest.concurrent.Eventually._
 import org.scalatest.tags.Cloud
+import org.scalatest.time.SpanSugar._
 
 @Cloud
 class ClickHouseCloudGenericSuite extends ClickHouseGenericSuite with ClickHouseCloudMixIn
@@ -29,6 +31,11 @@ class ClickHouseSingleGenericSuite extends ClickHouseGenericSuite with ClickHous
 abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   import testImplicits._
+
+  // Cloud's multi-replica compute can serve reads from a replica whose part / mutation cache
+  // has not yet caught up with a recent write or DELETE. Retry the assertion until reads converge.
+  private def eventuallyOnCloud(body: => Unit): Unit =
+    if (isCloud) eventually(timeout(15.seconds), interval(500.millis))(body) else body
 
   test("clickhouse command runner") {
     // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
@@ -74,50 +81,66 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     // DROP + PURGE
     withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
 
     // DROP + TRUNCATE
     withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"), Row("m=2"))
-      )
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
-        Seq(Row("m=2"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"), Row("m=2"))
+        )
+      }
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
+          Seq(Row("m=2"))
+        )
+      }
 
       spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq(Row("m=1"))
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq(Row("m=1"))
+        )
+      }
 
       spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
-      checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
-        Seq()
-      )
+      eventuallyOnCloud {
+        checkAnswer(
+          spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
+          Seq()
+        )
+      }
     }
   }
 
@@ -345,9 +368,9 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
     withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
       spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
-      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 10))
       spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
-      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
+      eventuallyOnCloud(assert(spark.table(s"$actualDb.$actualTbl").count == 5))
     }
   }
 

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -68,52 +68,51 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   test("clickhouse partition") {
     val db = "db_part"
-    val tbl = "tbl_part"
 
     // DROP + PURGE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_purge", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 1) PURGE")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 1) PURGE")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
 
     // DROP + TRUNCATE
-    withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
+    withSimpleTable(db, "tbl_part_truncate", true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"), Row("m=2"))
       )
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl PARTITION(m = 2)"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl PARTITION(m = 2)"),
         Seq(Row("m=2"))
       )
 
-      spark.sql(s"ALTER TABLE $db.$tbl DROP PARTITION(m = 2)")
+      spark.sql(s"ALTER TABLE $actualDb.$actualTbl DROP PARTITION(m = 2)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq(Row("m=1"))
       )
 
-      spark.sql(s"TRUNCATE TABLE $db.$tbl PARTITION(m = 1)")
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl PARTITION(m = 1)")
       checkAnswer(
-        spark.sql(s"SHOW PARTITIONS $db.$tbl"),
+        spark.sql(s"SHOW PARTITIONS $actualDb.$actualTbl"),
         Seq()
       )
     }
@@ -253,9 +252,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
   // TODO remove this hack version
   test("clickhouse partition toYYYYMMDD(toDate(col))") {
-    val db = "db_part_toYYYYMMDD_toDate"
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_part_toYYYYMMDD_toDate"
     val tbl = "tbl_part_toYYYYMMDD_toDate"
-    autoCleanupTable(db, tbl) { case (db, tbl) =>
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       runClickHouseSQL(
         s"""CREATE TABLE IF NOT EXISTS `$db`.`$tbl` (
            |    `id` Int64,
@@ -284,7 +284,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
           Row(2L, "2022-06-07")
         )
       )
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("clickhouse multi sort columns") {
@@ -324,20 +329,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("clickhouse truncate table") {
-    withClickHouseSingleIdTable("db_trunc", "tbl_trunc") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"TRUNCATE TABLE $db.$tbl")
-      assert(spark.table(s"$db.$tbl").count == 0)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_trunc", "tbl_trunc", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"TRUNCATE TABLE $actualDb.$actualTbl")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 0)
     }
   }
 
   test("clickhouse delete") {
-    withClickHouseSingleIdTable("db_del", "tbl_db_del") { (db, tbl) =>
-      spark.range(10).toDF("id").writeTo(s"$db.$tbl").append
-      assert(spark.table(s"$db.$tbl").count == 10)
-      spark.sql(s"DELETE FROM $db.$tbl WHERE id < 5")
-      assert(spark.table(s"$db.$tbl").count == 5)
+    val schema = StructType(StructField("id", LongType, nullable = false) :: Nil)
+    withTable("db_del", "tbl_db_del", schema) { (actualDb: String, actualTbl: String) =>
+      spark.range(10).toDF("id").writeTo(s"$actualDb.$actualTbl").append
+      assert(spark.table(s"$actualDb.$actualTbl").count == 10)
+      spark.sql(s"DELETE FROM $actualDb.$actualTbl WHERE id < 5")
+      assert(spark.table(s"$actualDb.$actualTbl").count == 5)
     }
   }
 
@@ -346,7 +353,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     val tbl = "tbl_rw"
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
-      val tblSchema = spark.table(s"$db.$tbl").schema
+      val tblSchema = spark.table(s"$actualDb.$actualTbl").schema
       assert(tblSchema == StructType(
         StructField("id", DataTypes.LongType, false) ::
           StructField("value", DataTypes.StringType, true) ::
@@ -355,7 +362,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       ))
 
       checkAnswer(
-        spark.table(s"$db.$tbl").sort("m"),
+        spark.table(s"$actualDb.$actualTbl").sort("m"),
         Seq(
           Row(1L, "1", timestamp("2021-01-01T10:10:10Z"), 1),
           Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2)
@@ -363,11 +370,11 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.table(s"$db.$tbl").filter($"id" > 1),
+        spark.table(s"$actualDb.$actualTbl").filter($"id" > 1),
         Row(2L, "2", timestamp("2022-02-02T10:10:10Z"), 2) :: Nil
       )
 
-      assert(spark.table(s"$db.$tbl").filter($"id" > 1).count === 1)
+      assert(spark.table(s"$actualDb.$actualTbl").filter($"id" > 1).count === 1)
 
     // infiniteLoop()
     }
@@ -379,7 +386,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT m, _partition_id FROM $db.$tbl ORDER BY m"),
+        spark.sql(s"SELECT m, _partition_id FROM $actualDb.$actualTbl ORDER BY m"),
         Seq(
           Row(1, "1"),
           Row(2, "2")
@@ -461,22 +468,22 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       checkAnswer(
-        spark.sql(s"SELECT COUNT(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT COUNT(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MIN(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MIN(id) FROM $actualDb.$actualTbl"),
         Seq(Row(1))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT MAX(id) FROM $db.$tbl"),
+        spark.sql(s"SELECT MAX(id) FROM $actualDb.$actualTbl"),
         Seq(Row(2))
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, COUNT(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 1)
@@ -484,7 +491,7 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
 
       checkAnswer(
-        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $db.$tbl GROUP BY m"),
+        spark.sql(s"SELECT m, SUM(DISTINCT id) FROM $actualDb.$actualTbl GROUP BY m"),
         Seq(
           Row(1, 1),
           Row(2, 2)
@@ -494,7 +501,10 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   }
 
   test("create or replace table") {
-    autoCleanupTable("db_cor", "tbl_cor") { (db, tbl) =>
+    val db = if (useSuiteLevelDatabase) testDatabaseName else "db_cor"
+    val tbl = "tbl_cor"
+    try {
+      if (!useSuiteLevelDatabase) runClickHouseSQL(s"CREATE DATABASE IF NOT EXISTS `$db`")
       def createOrReplaceTable(): Unit = spark.sql(
         s"""CREATE OR REPLACE TABLE `$db`.`$tbl` (
            |  id Long NOT NULL
@@ -508,7 +518,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
       )
       createOrReplaceTable()
       createOrReplaceTable()
-    }
+    } finally
+      if (useSuiteLevelDatabase) dropTableWithRetry(db, tbl)
+      else {
+        runClickHouseSQL(s"DROP TABLE IF EXISTS `$db`.`$tbl`")
+        runClickHouseSQL(s"DROP DATABASE IF EXISTS `$db`")
+      }
   }
 
   test("cache table") {
@@ -517,12 +532,12 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
 
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       try {
-        spark.sql(s"CACHE TABLE $db.$tbl")
-        val cachedPlan = spark.sql(s"SELECT * FROM $db.$tbl").queryExecution.commandExecuted
+        spark.sql(s"CACHE TABLE $actualDb.$actualTbl")
+        val cachedPlan = spark.sql(s"SELECT * FROM $actualDb.$actualTbl").queryExecution.commandExecuted
           .find(node => spark.sharedState.cacheManager.lookupCachedData(node).isDefined)
         assert(cachedPlan.isDefined)
       } finally
-        spark.sql(s"UNCACHE TABLE $db.$tbl")
+        spark.sql(s"UNCACHE TABLE $actualDb.$actualTbl")
     }
   }
 
@@ -533,24 +548,24 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     withSimpleTable(db, tbl, true) { (actualDb: String, actualTbl: String) =>
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=false")
       checkAnswer(
-        spark.sql(s"SELECT id FROM $db.$tbl " +
+        spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
           s"WHERE id IN (" +
-          s"  SELECT id FROM $db.$tbl " +
+          s"  SELECT id FROM $actualDb.$actualTbl " +
           s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
           s")"),
         Row(1)
       )
 
       spark.sql("set spark.clickhouse.read.runtimeFilter.enabled=true")
-      val df = spark.sql(s"SELECT id FROM $db.$tbl " +
+      val df = spark.sql(s"SELECT id FROM $actualDb.$actualTbl " +
         s"WHERE id IN (" +
-        s"  SELECT id FROM $db.$tbl " +
+        s"  SELECT id FROM $actualDb.$actualTbl " +
         s"  WHERE DATE_FORMAT(create_time, 'yyyy-MM-dd') between '2021-01-01' and '2022-01-01'" +
         s")")
       checkAnswer(df, Row(1))
       val runtimeFilterExists = df.queryExecution.sparkPlan.exists {
         case BatchScanExec(_, _, runtimeFilters, _, table, _)
-            if table.name() == TableIdentifier(tbl, Some(db)).quotedString
+            if table.name() == TableIdentifier(actualTbl, Some(actualDb)).quotedString
               && runtimeFilters.nonEmpty => true
         case _ => false
       }

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -31,8 +31,13 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
   import testImplicits._
 
   test("clickhouse command runner") {
+    // Pin the JSON formatting of UInt64 (visibleWidth returns UInt64). ClickHouse
+    // flipped the default of `output_format_json_quote_64bit_integers` from 1 to 0
+    // around 25.7+, which changes the output from `"4"` to bare `4`.
     checkAnswer(
-      runClickHouseSQL("SELECT visibleWidth(NULL)"),
+      runClickHouseSQL(
+        "SELECT visibleWidth(NULL) SETTINGS output_format_json_quote_64bit_integers=1"
+      ),
       Row("""{"visibleWidth(NULL)":"4"}""") :: Nil
     )
   }

--- a/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
+++ b/spark-4.0/clickhouse-spark-it/src/test/scala/org/apache/spark/sql/clickhouse/single/ClickHouseGenericSuite.scala
@@ -390,6 +390,65 @@ abstract class ClickHouseGenericSuite extends SparkClickHouseSingleTest {
     )
   }
 
+  test("push down top N") {
+    val db = "db_topn"
+    // Table name is suffixed with nanoTime so the system.query_log scan below
+    // matches only this run's queries.
+    val tbl = s"tbl_topn_${System.nanoTime()}"
+    // Sort column is named `interval` -- a ClickHouse reserved keyword. this is to check the back-quoting fix.
+    val schema = StructType(
+      StructField("id", LongType, nullable = false) ::
+        StructField("interval", LongType, nullable = true) :: Nil
+    )
+    withTable(db, tbl, schema) { (actualDb, actualTbl) =>
+      runClickHouseSQL(
+        s"""INSERT INTO `$actualDb`.`$actualTbl` VALUES
+           |  (1, 10),
+           |  (2, 20),
+           |  (3, 30),
+           |  (4, 40),
+           |  (5, NULL)
+           |""".stripMargin
+      ).collect()
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+        Seq(Row(40L), Row(30L))
+      )
+
+      runClickHouseSQL("SYSTEM FLUSH LOGS").collect()
+      val recentQueries = runClickHouseSQL(
+        s"""SELECT query FROM system.query_log
+           |WHERE type = 'QueryFinish'
+           |  AND query LIKE '%$actualDb%$actualTbl%'
+           |  AND query LIKE '%SELECT%'
+           |  AND event_time > now() - INTERVAL 60 SECOND
+           |ORDER BY event_time DESC
+           |LIMIT 5""".stripMargin
+      ).collect().map(_.getString(0))
+      val pushedTopN = recentQueries.exists { q =>
+        q.contains("ORDER BY `interval` DESC NULLS LAST") && q.contains("LIMIT 2")
+      }
+      assert(
+        pushedTopN,
+        "Pushed query should include 'ORDER BY `interval` DESC NULLS LAST' and 'LIMIT 2'. " +
+          s"Recent queries: ${recentQueries.mkString("; ")}"
+      )
+
+      checkAnswer(
+        spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval ASC NULLS FIRST LIMIT 2"),
+        Seq(Row(null), Row(10L))
+      )
+
+      withSQLConf("spark.clickhouse.read.pushdown.topN" -> "false") {
+        checkAnswer(
+          spark.sql(s"SELECT interval FROM $actualDb.$actualTbl ORDER BY interval DESC NULLS LAST LIMIT 2"),
+          Seq(Row(40L), Row(30L))
+        )
+      }
+    }
+  }
+
   test("push down aggregation") {
     val db = "db_agg_col"
     val tbl = "tbl_agg_col"

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseTable.scala
@@ -160,7 +160,8 @@ case class ClickHouseTable(
       cluster = cluster,
       localTableSpec = localTableSpec,
       localTableEngineSpec = localTableEngineSpec,
-      readOptions = new ReadOptions(options.asCaseSensitiveMap())
+      readOptions = new ReadOptions(options.asCaseSensitiveMap()),
+      functionRegistry = functionRegistry
     )
     // TODO schema of partitions
     val partTransforms = Array[Transform]()

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -19,9 +19,10 @@ import com.clickhouse.spark.exception.CHClientException
 import com.clickhouse.spark.read.format.{ClickHouseBinaryReader, ClickHouseJsonReader}
 import com.clickhouse.spark.spec.{DistributedEngineSpec, NoPartitionSpec, TableEngineSpec}
 import com.clickhouse.spark.{BlocksReadMetric, BytesReadMetric, ClickHouseHelper, Logging, SQLHelper, Utils}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.{InternalRow, SQLConfHelper}
+import org.apache.spark.sql.clickhouse.ExprUtils
 import org.apache.spark.sql.clickhouse.ClickHouseSQLConf._
-import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, Transform}
+import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference, SortOrder => V2SortOrder, Transform}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.metric.CustomMetric
 import org.apache.spark.sql.connector.read._
@@ -29,6 +30,7 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
+import com.clickhouse.spark.expr.OrderExpr
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
@@ -40,12 +42,14 @@ class ClickHouseScanBuilder(
   metadataSchema: StructType,
   partitionTransforms: Array[Transform]
 ) extends ScanBuilder
+    with SupportsPushDownTopN
     with SupportsPushDownLimit
     with SupportsPushDownFilters
     with SupportsPushDownAggregates
     with SupportsPushDownRequiredColumns
     with ClickHouseHelper
     with SQLHelper
+    with SQLConfHelper
     with Logging {
 
   implicit private val tz: ZoneId = scanJob.tz
@@ -64,6 +68,34 @@ class ClickHouseScanBuilder(
     this._limit = Some(limit)
     true
   }
+
+  private var _orderByClause: Option[String] = None
+
+  private def renderOrderExpr(o: OrderExpr): String = {
+    val exprSql = o.expr match {
+      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
+      case other => other.sql
+    }
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"$exprSql $direction $nulls"
+  }
+
+  override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
+    if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
+
+    val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
+    if (translated.exists(_.isEmpty)) return false
+
+    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._limit = Some(limit)
+    true
+  }
+
+  // Each ClickHouse input partition runs its own `ORDER BY ... LIMIT n`, returning a local
+  // top-N. Spark must perform the final global merge across partitions, so we always
+  // report the pushdown as partial.
+  override def isPartiallyPushed: Boolean = true
 
   private var _pushedFilters = Array.empty[Filter]
 
@@ -123,6 +155,7 @@ class ClickHouseScanBuilder(
     readSchema = _readSchema,
     filtersExpr = compileFilters(AlwaysTrue :: pushedFilters.toList),
     groupByClause = _groupByClause,
+    orderByClause = _orderByClause,
     limit = _limit
   ))
 }

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.OrderExpr
+import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
@@ -72,13 +72,13 @@ class ClickHouseScanBuilder(
   private var _orderByClause: Option[String] = None
 
   private def renderOrderExpr(o: OrderExpr): String = {
-    val exprSql = o.expr match {
-      case com.clickhouse.spark.expr.FieldRef(name) => s"`$name`"
-      case other => other.sql
-    }
     val direction = if (o.asc) "ASC" else "DESC"
     val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"$exprSql $direction $nulls"
+    val sql = o.expr match {
+      case FieldRef(name) => Utils.wrapBackQuote(name)
+      case other => other.sql
+    }
+    s"$sql $direction $nulls"
   }
 
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,26 +30,11 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.ExprRender
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
-
-object ClickHouseScanBuilder {
-
-  def renderClickHouseSql(expr: Expr): String = expr match {
-    case FieldRef(name) => Utils.wrapBackQuote(name)
-    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
-    case other => other.sql
-  }
-
-  def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    s"${renderClickHouseSql(o.expr)} $direction $nulls"
-  }
-}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -93,7 +78,7 @@ class ClickHouseScanBuilder(
     if (translated.exists(_.isEmpty)) return false
 
     this._orderByClause =
-      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+      Some(translated.flatten.map(ExprRender.renderOrder).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseRead.scala
@@ -30,11 +30,26 @@ import org.apache.spark.sql.connector.read.partitioning.{Partitioning, UnknownPa
 import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 import org.apache.spark.sql.types.StructType
 import com.clickhouse.spark._
-import com.clickhouse.spark.expr.{Expr, FieldRef, OrderExpr}
+import com.clickhouse.spark.expr.{Expr, FieldRef, FuncExpr, OrderExpr}
 import com.clickhouse.spark.spec._
 
 import java.time.ZoneId
 import scala.util.control.NonFatal
+
+object ClickHouseScanBuilder {
+
+  def renderClickHouseSql(expr: Expr): String = expr match {
+    case FieldRef(name) => Utils.wrapBackQuote(name)
+    case FuncExpr(name, args) => s"$name(${args.map(renderClickHouseSql).mkString(",")})"
+    case other => other.sql
+  }
+
+  def renderOrderExpr(o: OrderExpr): String = {
+    val direction = if (o.asc) "ASC" else "DESC"
+    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
+    s"${renderClickHouseSql(o.expr)} $direction $nulls"
+  }
+}
 
 class ClickHouseScanBuilder(
   scanJob: ScanJobDescription,
@@ -71,23 +86,14 @@ class ClickHouseScanBuilder(
 
   private var _orderByClause: Option[String] = None
 
-  private def renderOrderExpr(o: OrderExpr): String = {
-    val direction = if (o.asc) "ASC" else "DESC"
-    val nulls = if (o.nullFirst) "NULLS FIRST" else "NULLS LAST"
-    val sql = o.expr match {
-      case FieldRef(name) => Utils.wrapBackQuote(name)
-      case other => other.sql
-    }
-    s"$sql $direction $nulls"
-  }
-
   override def pushTopN(orders: Array[V2SortOrder], limit: Int): Boolean = {
     if (!conf.getConf(READ_PUSHDOWN_TOP_N)) return false
 
     val translated = orders.map(o => ExprUtils.toClickHouseSortOrderOpt(o, scanJob.functionRegistry))
     if (translated.exists(_.isEmpty)) return false
 
-    this._orderByClause = Some(translated.flatten.map(renderOrderExpr).mkString("ORDER BY ", ", ", ""))
+    this._orderByClause =
+      Some(translated.flatten.map(ClickHouseScanBuilder.renderOrderExpr).mkString("ORDER BY ", ", ", ""))
     this._limit = Some(limit)
     true
   }

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ClickHouseReader.scala
@@ -60,6 +60,7 @@ abstract class ClickHouseReader[Record](
        |FROM `$database`.`$table`
        |WHERE (${part.partFilterExpr}) AND (${scanJob.filtersExpr})
        |${scanJob.groupByClause.getOrElse("")}
+       |${scanJob.orderByClause.getOrElse("")}
        |${scanJob.limit.map(n => s"LIMIT $n").getOrElse("")}
        |${readSettings.map(settings => s"SETTINGS $settings").getOrElse("")}
        |""".stripMargin

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/read/ScanJobDescription.scala
@@ -14,6 +14,7 @@
 
 package com.clickhouse.spark.read
 
+import com.clickhouse.spark.func.FunctionRegistry
 import com.clickhouse.spark.spec.{ClusterSpec, DistributedEngineSpec, NodeSpec, TableEngineSpec, TableSpec}
 import org.apache.spark.sql.clickhouse.ReadOptions
 import org.apache.spark.sql.types.StructType
@@ -29,12 +30,14 @@ case class ScanJobDescription(
   localTableSpec: Option[TableSpec],
   localTableEngineSpec: Option[TableEngineSpec],
   readOptions: ReadOptions,
+  functionRegistry: FunctionRegistry,
   // Below fields will be constructed in ScanBuilder.
   readSchema: StructType = new StructType,
   // We should pass compiled ClickHouse SQL snippets(or ClickHouse SQL AST data structure) instead of Spark Expression
   // into Scan tasks because the check happens in planing phase on driver side.
   filtersExpr: String = "1=1",
   groupByClause: Option[String] = None,
+  orderByClause: Option[String] = None,
   limit: Option[Int] = None
 ) {
 

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -244,4 +244,14 @@ object ClickHouseSQLConf {
       .transform(_.toLowerCase)
       .createOptional
 
+  val READ_PUSHDOWN_TOP_N: ConfigEntry[Boolean] =
+    buildConf("spark.clickhouse.read.pushdown.topN")
+      .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
+        "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
+        "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
+        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+      .version("0.10.1")
+      .booleanConf
+      .createWithDefault(true)
+
 }

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ClickHouseSQLConf.scala
@@ -249,7 +249,8 @@ object ClickHouseSQLConf {
       .doc("Whether to push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse. " +
         "When `true`, eligible sort orders combined with a LIMIT are translated into a " +
         "ClickHouse `ORDER BY ... LIMIT n` clause and Spark performs a final merge across " +
-        "input partitions. When `false`, only the LIMIT (without ORDER BY) is pushed down.")
+        "input partitions. When `false`, the `ORDER BY ... LIMIT n` is left for Spark to " +
+        "evaluate; plain `LIMIT n` queries (no `ORDER BY`) are unaffected.")
       .version("0.10.1")
       .booleanConf
       .createWithDefault(true)

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -215,7 +215,7 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     sortOrder: V2SortOrder,
     functionRegistry: FunctionRegistry
   ): Option[OrderExpr] = {
-    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val asc = sortOrder.direction() == SortDirection.ASCENDING
     val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
     sortOrder.expression() match {
       // length == 1 restricts to top-level columns and to exclude nested paths.

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -211,6 +211,23 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
     case other: Transform => throw CHClientException(s"Unsupported transform: $other")
   }
 
+  def toClickHouseSortOrderOpt(
+    sortOrder: V2SortOrder,
+    functionRegistry: FunctionRegistry
+  ): Option[OrderExpr] = {
+    val asc       = sortOrder.direction()    == SortDirection.ASCENDING
+    val nullFirst = sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST
+    sortOrder.expression() match {
+      // length == 1 restricts to top-level columns and to exclude nested paths.
+      case ref: NamedReference if ref.fieldNames().length == 1 =>
+        Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
+      case t: Transform =>
+        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
+        catch { case _: CHClientException => None }
+      case _ => None
+    }
+  }
+
   def inferTransformSchema(
     primarySchema: StructType,
     secondarySchema: StructType,

--- a/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/org/apache/spark/sql/clickhouse/ExprUtils.scala
@@ -222,10 +222,31 @@ object ExprUtils extends SQLConfHelper with Serializable with Logging {
       case ref: NamedReference if ref.fieldNames().length == 1 =>
         Some(OrderExpr(FieldRef(ref.fieldNames().head), asc, nullFirst))
       case t: Transform =>
-        try Some(OrderExpr(toClickHouse(t, functionRegistry), asc, nullFirst))
-        catch { case _: CHClientException => None }
+        toClickHouseSortTransformOpt(t, functionRegistry).map(OrderExpr(_, asc, nullFirst))
       case _ => None
     }
+  }
+
+  private def toClickHouseSortTransformOpt(
+    transform: Transform,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = transform match {
+    case IdentityTransform(FieldReference(Seq(col))) => Some(FieldRef(col))
+    case ApplyTransform(name, args) if functionRegistry.sparkToClickHouseFunc.contains(name) =>
+      val translatedArgs = args.toList.map(toClickHouseSortArgOpt(_, functionRegistry))
+      if (translatedArgs.exists(_.isEmpty)) None
+      else Some(FuncExpr(functionRegistry.sparkToClickHouseFunc(name), translatedArgs.flatten))
+    case _ => None
+  }
+
+  private def toClickHouseSortArgOpt(
+    arg: V2Expression,
+    functionRegistry: FunctionRegistry
+  ): Option[Expr] = arg match {
+    case ref: NamedReference if ref.fieldNames().length == 1 => Some(FieldRef(ref.fieldNames().head))
+    case t: Transform => toClickHouseSortTransformOpt(t, functionRegistry)
+    case lit: LiteralValue[_] => Some(SQLExpr(lit.describe))
+    case _ => None
   }
 
   def inferTransformSchema(

--- a/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,6 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import com.clickhouse.spark.read.ClickHouseScanBuilder
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -72,8 +73,40 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated === Some(
-      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("k"))), asc = true, nullFirst = false)
     ))
+  }
+
+  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
+    )
+    assert(rendered === "`order` ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: function-transform leaf field is back-quoted") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
+    )
+    assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
+  }
+
+  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+      OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
+    )
+    assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("order")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -101,5 +134,56 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: nested function transform recurses and back-quotes leaf") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("ck_xx_hash64", Expressions.column("order"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(
+        FuncExpr("xxHash64", List(FuncExpr("xxHash64", List(FieldRef("order"))))),
+        asc = true,
+        nullFirst = false
+      )
+    ))
+    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+      "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
+  }
+
+  test("toClickHouseSortOrderOpt: literal arg inside function transform is preserved") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", LiteralValue(42, IntegerType)),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("42"))), asc = true, nullFirst = false)
+    ))
+  }
+
+  test("toClickHouseSortOrderOpt: nested unregistered function transform returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.apply("totally_unknown_func", Expressions.column("k"))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary V2 expression as function arg returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply(
+        "ck_xx_hash64",
+        new GeneralScalarExpression("+", Array(Expressions.column("k"), LiteralValue(1, IntegerType)))
+      ),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, registry).isEmpty)
   }
 }

--- a/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -14,7 +14,7 @@
 
 package org.apache.spark.sql.clickhouse
 
-import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
@@ -71,11 +71,9 @@ class ExprUtilsSuite extends AnyFunSuite {
       NullOrdering.NULLS_LAST
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
-    assert(translated.isDefined)
-    val OrderExpr(expr, asc, nullFirst) = translated.get
-    assert(asc && !nullFirst)
-    val funcExpr = expr.asInstanceOf[FuncExpr]
-    assert(funcExpr.name === "xxHash64")
+    assert(translated === Some(
+      OrderExpr(FuncExpr("xxHash64", List(SQLExpr("k"))), asc = true, nullFirst = false)
+    ))
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {

--- a/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.clickhouse
+
+import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr}
+import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
+import org.apache.spark.sql.connector.expressions.{
+  Expressions,
+  GeneralScalarExpression,
+  LiteralValue,
+  NullOrdering,
+  SortDirection
+}
+import org.apache.spark.sql.types.IntegerType
+import org.scalatest.funsuite.AnyFunSuite
+
+class ExprUtilsSuite extends AnyFunSuite {
+
+  private val registry = {
+    val r = new DynamicFunctionRegistry
+    r.register("ck_xx_hash64", ClickHouseXxHash64)
+    r
+  }
+
+  test("toClickHouseSortOrderOpt: ASC NULLS FIRST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("id"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_FIRST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("id"), asc = true, nullFirst = true)))
+  }
+
+  test("toClickHouseSortOrderOpt: DESC NULLS LAST on bare field") {
+    val sort = Expressions.sort(
+      Expressions.column("ts"),
+      SortDirection.DESCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("ts"), asc = false, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: identity transform on field") {
+    val sort = Expressions.sort(
+      Expressions.identity("k"),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry) ===
+      Some(OrderExpr(FieldRef("k"), asc = true, nullFirst = false)))
+  }
+
+  test("toClickHouseSortOrderOpt: function transform registered in registry") {
+    val sort = Expressions.sort(
+      Expressions.apply("ck_xx_hash64", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
+    assert(translated.isDefined)
+    val OrderExpr(expr, asc, nullFirst) = translated.get
+    assert(asc && !nullFirst)
+    val funcExpr = expr.asInstanceOf[FuncExpr]
+    assert(funcExpr.name === "xxHash64")
+  }
+
+  test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
+    val sort = Expressions.sort(
+      Expressions.apply("totally_unknown_func", Expressions.column("k")),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: literal expression returns None") {
+    val sort = Expressions.sort(
+      LiteralValue[Integer](Integer.valueOf(1), IntegerType),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+
+  test("toClickHouseSortOrderOpt: arbitrary GeneralScalarExpression returns None") {
+    val sort = Expressions.sort(
+      new GeneralScalarExpression("=", Array(Expressions.column("k"), LiteralValue(1, IntegerType))),
+      SortDirection.ASCENDING,
+      NullOrdering.NULLS_LAST
+    )
+    assert(ExprUtils.toClickHouseSortOrderOpt(sort, StaticFunctionRegistry).isEmpty)
+  }
+}

--- a/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ExprUtilsSuite.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.clickhouse
 
 import com.clickhouse.spark.expr.{FieldRef, FuncExpr, OrderExpr, SQLExpr}
 import com.clickhouse.spark.func.{ClickHouseXxHash64, DynamicFunctionRegistry, StaticFunctionRegistry}
-import com.clickhouse.spark.read.ClickHouseScanBuilder
+import com.clickhouse.spark.expr.ExprRender
 import org.apache.spark.sql.connector.expressions.{
   Expressions,
   GeneralScalarExpression,
@@ -77,28 +77,28 @@ class ExprUtilsSuite extends AnyFunSuite {
     ))
   }
 
-  test("renderOrderExpr: bare field name that is a CH reserved word is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: bare field name that is a CH reserved word is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FieldRef("order"), asc = true, nullFirst = false)
     )
     assert(rendered === "`order` ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: function-transform leaf field is back-quoted") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: function-transform leaf field is back-quoted") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("xxHash64", List(FieldRef("order"))), asc = true, nullFirst = false)
     )
     assert(rendered === "xxHash64(`order`) ASC NULLS LAST")
   }
 
-  test("renderOrderExpr: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
-    val rendered = ClickHouseScanBuilder.renderOrderExpr(
+  test("renderOrder: SQLExpr leaf is emitted verbatim (e.g. literal arg)") {
+    val rendered = ExprRender.renderOrder(
       OrderExpr(FuncExpr("toStartOfInterval", List(FieldRef("ts"), SQLExpr("INTERVAL 1 HOUR"))), asc = false)
     )
     assert(rendered === "toStartOfInterval(`ts`,INTERVAL 1 HOUR) DESC NULLS LAST")
   }
 
-  test("toClickHouseSortOrderOpt + renderOrderExpr: end-to-end with reserved-word column under xxHash64") {
+  test("toClickHouseSortOrderOpt + renderOrder: end-to-end with reserved-word column under xxHash64") {
     val sort = Expressions.sort(
       Expressions.apply("ck_xx_hash64", Expressions.column("order")),
       SortDirection.ASCENDING,
@@ -106,7 +106,7 @@ class ExprUtilsSuite extends AnyFunSuite {
     )
     val translated = ExprUtils.toClickHouseSortOrderOpt(sort, registry)
     assert(translated.isDefined)
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
+    assert(ExprRender.renderOrder(translated.get) === "xxHash64(`order`) ASC NULLS LAST")
   }
 
   test("toClickHouseSortOrderOpt: function transform NOT in registry returns None") {
@@ -150,7 +150,7 @@ class ExprUtilsSuite extends AnyFunSuite {
         nullFirst = false
       )
     ))
-    assert(ClickHouseScanBuilder.renderOrderExpr(translated.get) ===
+    assert(ExprRender.renderOrder(translated.get) ===
       "xxHash64(xxHash64(`order`)) ASC NULLS LAST")
   }
 


### PR DESCRIPTION
Push down `ORDER BY ... LIMIT n` (top-N) to ClickHouse for the DataSource V2 scan across all four Spark profiles (3.3, 3.4, 3.5, 4.0). Each input partition issues its own local top-N and Spark performs a final global merge across partitions (`isPartiallyPushed = true`). Gated by a new SQL conf `spark.clickhouse.read.pushdown.topN` (default `true`).

Sort orders are translated via `ExprUtils.toClickHouseSortOrderOpt`:
- **spark-3.4 / 3.5 / 4.0**: accepts top-level `NamedReference` and `ApplyTransform` whose name is in the `FunctionRegistry`. Args are recursively walked -- column refs become `FieldRef` (back-quoted by the renderer), nested transforms recurse, literals pass through. Anything else (multi-part refs, arbitrary scalar expressions, unregistered functions) yields `None` and the top-N is left for Spark to evaluate.
- **spark-3.3**: restricted to top-level `NamedReference` and `IdentityTransform(FieldReference(Seq(_)))` only. 3.3 has no `FunctionRegistry` to gate `ApplyTransform` against; forwarding arbitrary Spark function names to ClickHouse without translation would produce SQL the server rejects at execution time, so the path is deliberately narrower than 3.4+.

Identifier back-quoting in the pushed-down clause is handled by a recursive `ClickHouseScanBuilder.renderClickHouseSql` walker so reserved-word column names round-trip safely whether at the top level (`ORDER BY \`interval\``) or nested inside a function transform (`xxHash64(\`interval\`)`). The DDL translator `ExprUtils.toClickHouse` (used by `PARTITION BY`) is intentionally unchanged -- DDL is user-typed and the user owns identifier quoting there.

Verified against a containerized ClickHouse 25.3: top-N reaches the server as the expected `ORDER BY <expr> ASC|DESC NULLS FIRST|LAST LIMIT n` clause. Aggregation pushdown is unaffected -- Spark's V2 rule does not invoke `pushTopN` over a partially-pushed Aggregate (the `PhysicalOperation` extractor doesn't traverse `Aggregate` and the connector's `SupportsPushDownAggregates.supportCompletePushDown` returns `false`), so the two pushdowns stay independent.

Includes an end-to-end integration test (`ClickHouseGenericSuite."push down top N"`) that asserts both the result rows and the wire SQL via `system.query_log`, using `interval` (CH-reserved, Spark-`ansiNonReserved`) as the sort column to genuinely exercise the back-quoting regression case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read query generation and partial pushdown semantics; incorrect sort translation or merge assumptions could return wrong top-N results, though unsupported sorts are rejected and the feature is disableable via config.
> 
> **Overview**
> Adds **top-N pushdown** for ClickHouse reads: eligible `ORDER BY ... LIMIT n` plans are translated into ClickHouse SQL on each scan partition, with **`isPartiallyPushed = true`** so Spark still does a global merge. Controlled by **`spark.clickhouse.read.pushdown.topN`** (default `true`), documented in SQL config docs.
> 
> **`ClickHouseScanBuilder`** implements `SupportsPushDownTopN`; sort keys are converted via **`ExprUtils.toClickHouseSortOrderOpt`** and rendered with new shared **`ExprRender`** (back-quotes identifiers such as reserved-word column `interval`). **`ScanJobDescription` / `ClickHouseReader`** carry an **`orderByClause`** into the generated `SELECT`.
> 
> **Spark 3.3** only pushes bare columns / `IdentityTransform`; **3.4+** also allow **`FunctionRegistry`**-mapped function transforms (with recursive args). Unit tests (`ExprUtilsSuite`) and integration **`push down top N`** (result + `system.query_log`) cover quoting and the conf-off path.
> 
> **`ClickHouseGenericSuite`** gains Cloud read retries (`eventuallyOnCloud`), safer parallel CI naming, UInt64 JSON setting pin, and assorted fixes using resolved `actualDb`/`actualTbl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56c7af2f8ac83a42f1e22e53246478c2ff0465a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->