### PR TITLE
ci: declare workflow-level `contents: read` on 5 workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,6 +27,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -23,6 +23,9 @@ on:
       - "branch-*"
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   check-license:
     runs-on: ubuntu-22.04

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -19,6 +19,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonar-report:
     if: ${{ startsWith(github.repository, 'clickhouse/') }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,6 +24,9 @@ on:
       - "branch-*"
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   check-style:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -27,6 +27,9 @@ on:
     # Nightly run at 02:00 UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   run-tpcds-sf1:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 5 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI hardening with read-only token scope; no application or runtime behavior changes.
> 
> **Overview**
> Adds workflow-level **`permissions: contents: read`** to five GitHub Actions workflows: **Build and Test**, **Check License**, **SonarQube**, **Check Style**, and **TPC-DS**.
> 
> This caps the default **`GITHUB_TOKEN`** to read-only repo access for those runs (checkout and similar), instead of inheriting broader org/repo defaults. It aligns with supply-chain hardening (e.g. post–CVE-2025-30066) and OpenSSF Scorecard **Token-Permissions** expectations. **No job steps, matrices, or triggers are changed.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c775e81d93f49e79361d61445a1e3ed470f4e22b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->