### PR TITLE
fix: honor ClickHouse use_time_zone option

### DIFF
--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -71,7 +71,7 @@ class ClickHouseCatalog extends TableCatalog
 
     this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT 1")
 
-    this.tz = options.get(CATALOG_PROP_TZ) match {
+    this.tz = catalogTimeZone(options) match {
       case tz if tz == null || tz.isEmpty || tz.toLowerCase == "server" =>
         val timezoneOutput = this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT timezone() AS tz")
         assert(timezoneOutput.rows == 1)

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
@@ -49,6 +49,12 @@ trait ClickHouseHelper extends SQLConfHelper with Logging {
     case _ => None
   }
 
+  def catalogTimeZone(options: CaseInsensitiveStringMap): String =
+    Option(options.get(CATALOG_PROP_TZ))
+      .filter(_.nonEmpty)
+      .orElse(Option(options.get(CATALOG_PROP_OPTION_TZ)).filter(_.nonEmpty))
+      .getOrElse("server")
+
   def buildNodeSpec(options: CaseInsensitiveStringMap): NodeSpec = {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))

--- a/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
+++ b/spark-3.3/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
@@ -31,6 +31,7 @@ object Constants {
   final val CATALOG_PROP_TZ             = "timezone" // server(default), client, UTC+3, Asia/Shanghai, etc.
   final val CATALOG_INFER_RUNTIME_ENV   = "infer_runtime_env"
   final val CATALOG_PROP_OPTION_PREFIX  = "option."
+  final val CATALOG_PROP_OPTION_TZ      = CATALOG_PROP_OPTION_PREFIX + USE_TIME_ZONE.getKey
   final val CATALOG_PROP_IGNORE_OPTIONS = Seq(
     DATABASE.getKey, COMPRESS.getKey, DECOMPRESS.getKey, FORMAT.getKey, RETRY.getKey,
     USE_SERVER_TIME_ZONE.getKey, USE_SERVER_TIME_ZONE_FOR_DATES.getKey, SERVER_TIME_ZONE.getKey, USE_TIME_ZONE.getKey,

--- a/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
+++ b/spark-3.3/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
@@ -29,11 +29,30 @@ class ClickHouseHelperSuite extends AnyFunSuite with ClickHouseHelper {
       new CaseInsensitiveStringMap(Map(
         "database" -> "testing",
         "option.database" -> "production",
+        "option.use_time_zone" -> "Asia/Shanghai",
         "option.ssl" -> "true"
       ).asJava)
     )
     assert(nodeSpec.database === "testing")
+    assert(!nodeSpec.options.containsKey("use_time_zone"))
     assert(nodeSpec.options.get("ssl") === "true")
+  }
+
+  test("catalog timezone uses ClickHouse client option as fallback") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "Asia/Shanghai")
+  }
+
+  test("catalog timezone takes precedence over ClickHouse client option") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "timezone" -> "client",
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "client")
   }
 
   test("client query timeout uses SQLConf") {

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -71,7 +71,7 @@ class ClickHouseCatalog extends TableCatalog
 
     this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT 1")
 
-    this.tz = options.get(CATALOG_PROP_TZ) match {
+    this.tz = catalogTimeZone(options) match {
       case tz if tz == null || tz.isEmpty || tz.toLowerCase == "server" =>
         val timezoneOutput = this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT timezone() AS tz")
         assert(timezoneOutput.rows == 1)

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
@@ -49,6 +49,12 @@ trait ClickHouseHelper extends SQLConfHelper with Logging {
     case _ => None
   }
 
+  def catalogTimeZone(options: CaseInsensitiveStringMap): String =
+    Option(options.get(CATALOG_PROP_TZ))
+      .filter(_.nonEmpty)
+      .orElse(Option(options.get(CATALOG_PROP_OPTION_TZ)).filter(_.nonEmpty))
+      .getOrElse("server")
+
   def buildNodeSpec(options: CaseInsensitiveStringMap): NodeSpec = {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))

--- a/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
+++ b/spark-3.4/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
@@ -31,6 +31,7 @@ object Constants {
   final val CATALOG_PROP_TZ             = "timezone" // server(default), client, UTC+3, Asia/Shanghai, etc.
   final val CATALOG_INFER_RUNTIME_ENV   = "infer_runtime_env"
   final val CATALOG_PROP_OPTION_PREFIX  = "option."
+  final val CATALOG_PROP_OPTION_TZ      = CATALOG_PROP_OPTION_PREFIX + USE_TIME_ZONE.getKey
   final val CATALOG_PROP_IGNORE_OPTIONS = Seq(
     DATABASE.getKey, COMPRESS.getKey, DECOMPRESS.getKey, FORMAT.getKey, RETRY.getKey,
     USE_SERVER_TIME_ZONE.getKey, USE_SERVER_TIME_ZONE_FOR_DATES.getKey, SERVER_TIME_ZONE.getKey, USE_TIME_ZONE.getKey,

--- a/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
+++ b/spark-3.4/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
@@ -29,11 +29,30 @@ class ClickHouseHelperSuite extends AnyFunSuite with ClickHouseHelper {
       new CaseInsensitiveStringMap(Map(
         "database" -> "testing",
         "option.database" -> "production",
+        "option.use_time_zone" -> "Asia/Shanghai",
         "option.ssl" -> "true"
       ).asJava)
     )
     assert(nodeSpec.database === "testing")
+    assert(!nodeSpec.options.containsKey("use_time_zone"))
     assert(nodeSpec.options.get("ssl") === "true")
+  }
+
+  test("catalog timezone uses ClickHouse client option as fallback") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "Asia/Shanghai")
+  }
+
+  test("catalog timezone takes precedence over ClickHouse client option") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "timezone" -> "client",
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "client")
   }
 
   test("client query timeout uses SQLConf") {

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -82,7 +82,7 @@ class ClickHouseCatalog extends TableCatalog
 
     this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT 1")
 
-    this.tz = options.get(CATALOG_PROP_TZ) match {
+    this.tz = catalogTimeZone(options) match {
       case tz if tz == null || tz.isEmpty || tz.toLowerCase == "server" =>
         val timezoneOutput = this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT timezone() AS tz")
         assert(timezoneOutput.rows == 1)

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
@@ -59,6 +59,12 @@ trait ClickHouseHelper extends SQLConfHelper with Logging {
     case _ => None
   }
 
+  def catalogTimeZone(options: CaseInsensitiveStringMap): String =
+    Option(options.get(CATALOG_PROP_TZ))
+      .filter(_.nonEmpty)
+      .orElse(Option(options.get(CATALOG_PROP_OPTION_TZ)).filter(_.nonEmpty))
+      .getOrElse("server")
+
   def buildNodeSpec(options: CaseInsensitiveStringMap): NodeSpec = {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))

--- a/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
+++ b/spark-3.5/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
@@ -31,6 +31,7 @@ object Constants {
   final val CATALOG_PROP_TZ             = "timezone" // server(default), client, UTC+3, Asia/Shanghai, etc.
   final val CATALOG_INFER_RUNTIME_ENV   = "infer_runtime_env"
   final val CATALOG_PROP_OPTION_PREFIX  = "option."
+  final val CATALOG_PROP_OPTION_TZ      = CATALOG_PROP_OPTION_PREFIX + USE_TIME_ZONE.getKey
   final val CATALOG_PROP_IGNORE_OPTIONS = Seq(
     DATABASE.getKey, COMPRESS.getKey, DECOMPRESS.getKey, FORMAT.getKey, RETRY.getKey,
     USE_SERVER_TIME_ZONE.getKey, USE_SERVER_TIME_ZONE_FOR_DATES.getKey, SERVER_TIME_ZONE.getKey, USE_TIME_ZONE.getKey,

--- a/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
+++ b/spark-3.5/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
@@ -29,11 +29,30 @@ class ClickHouseHelperSuite extends AnyFunSuite with ClickHouseHelper {
       new CaseInsensitiveStringMap(Map(
         "database" -> "testing",
         "option.database" -> "production",
+        "option.use_time_zone" -> "Asia/Shanghai",
         "option.ssl" -> "true"
       ).asJava)
     )
     assert(nodeSpec.database === "testing")
+    assert(!nodeSpec.options.containsKey("use_time_zone"))
     assert(nodeSpec.options.get("ssl") === "true")
+  }
+
+  test("catalog timezone uses ClickHouse client option as fallback") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "Asia/Shanghai")
+  }
+
+  test("catalog timezone takes precedence over ClickHouse client option") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "timezone" -> "client",
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "client")
   }
 
   test("client query timeout uses SQLConf") {

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseCatalog.scala
@@ -82,7 +82,7 @@ class ClickHouseCatalog extends TableCatalog
 
     this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT 1")
 
-    this.tz = options.get(CATALOG_PROP_TZ) match {
+    this.tz = catalogTimeZone(options) match {
       case tz if tz == null || tz.isEmpty || tz.toLowerCase == "server" =>
         val timezoneOutput = this.nodeClient.syncQueryAndCheckOutputJSONEachRow("SELECT timezone() AS tz")
         assert(timezoneOutput.rows == 1)

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/ClickHouseHelper.scala
@@ -59,6 +59,12 @@ trait ClickHouseHelper extends SQLConfHelper with Logging {
     case _ => None
   }
 
+  def catalogTimeZone(options: CaseInsensitiveStringMap): String =
+    Option(options.get(CATALOG_PROP_TZ))
+      .filter(_.nonEmpty)
+      .orElse(Option(options.get(CATALOG_PROP_OPTION_TZ)).filter(_.nonEmpty))
+      .getOrElse("server")
+
   def buildNodeSpec(options: CaseInsensitiveStringMap): NodeSpec = {
     val clientOpts = options.asScala
       .filterKeys(_.startsWith(CATALOG_PROP_OPTION_PREFIX))

--- a/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
+++ b/spark-4.0/clickhouse-spark/src/main/scala/com/clickhouse/spark/Constants.scala
@@ -31,6 +31,7 @@ object Constants {
   final val CATALOG_PROP_TZ             = "timezone" // server(default), client, UTC+3, Asia/Shanghai, etc.
   final val CATALOG_INFER_RUNTIME_ENV   = "infer_runtime_env"
   final val CATALOG_PROP_OPTION_PREFIX  = "option."
+  final val CATALOG_PROP_OPTION_TZ      = CATALOG_PROP_OPTION_PREFIX + USE_TIME_ZONE.getKey
   final val CATALOG_PROP_IGNORE_OPTIONS = Seq(
     DATABASE.getKey, COMPRESS.getKey, DECOMPRESS.getKey, FORMAT.getKey, RETRY.getKey,
     USE_SERVER_TIME_ZONE.getKey, USE_SERVER_TIME_ZONE_FOR_DATES.getKey, SERVER_TIME_ZONE.getKey, USE_TIME_ZONE.getKey,

--- a/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
+++ b/spark-4.0/clickhouse-spark/src/test/scala/org/apache/spark/sql/clickhouse/ClickHouseHelperSuite.scala
@@ -29,11 +29,30 @@ class ClickHouseHelperSuite extends AnyFunSuite with ClickHouseHelper {
       new CaseInsensitiveStringMap(Map(
         "database" -> "testing",
         "option.database" -> "production",
+        "option.use_time_zone" -> "Asia/Shanghai",
         "option.ssl" -> "true"
       ).asJava)
     )
     assert(nodeSpec.database === "testing")
+    assert(!nodeSpec.options.containsKey("use_time_zone"))
     assert(nodeSpec.options.get("ssl") === "true")
+  }
+
+  test("catalog timezone uses ClickHouse client option as fallback") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "Asia/Shanghai")
+  }
+
+  test("catalog timezone takes precedence over ClickHouse client option") {
+    val options = new CaseInsensitiveStringMap(Map(
+      "timezone" -> "client",
+      "option.use_time_zone" -> "Asia/Shanghai"
+    ).asJava)
+
+    assert(catalogTimeZone(options) === "client")
   }
 
   test("client query timeout uses SQLConf") {


### PR DESCRIPTION
Fixes #387.

`option.use_time_zone` is currently filtered out before the ClickHouse client options are built, but the catalog timezone selection only reads the connector-specific `timezone` option. That makes a user-provided ClickHouse `use_time_zone` value look ignored.

This change keeps filtering `use_time_zone` out of the raw client option map, but also treats `option.use_time_zone` as a fallback for the catalog timezone when `timezone` is not set. An explicit `timezone` value still wins.

Tests added for all supported Spark source trees verify:
- `option.use_time_zone` is not passed into `NodeSpec.options`
- `option.use_time_zone` is used as the catalog timezone fallback
- `timezone` has precedence over `option.use_time_zone`

Validation:
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 GRADLE_USER_HOME=$PWD/.gradle-home ./gradlew --no-daemon ':clickhouse-spark-4.0_2.13:test' --tests=org.apache.spark.sql.clickhouse.ClickHouseHelperSuite`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 GRADLE_USER_HOME=$PWD/.gradle-home ./gradlew --no-daemon -Dspark_binary_version=3.3 -Dscala_binary_version=2.12 ':clickhouse-spark-3.3_2.12:test' --tests=org.apache.spark.sql.clickhouse.ClickHouseHelperSuite`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 GRADLE_USER_HOME=$PWD/.gradle-home ./gradlew --no-daemon ':clickhouse-spark-4.0_2.13:spotlessCheck'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the catalog picks its timezone, which affects DateTime parsing and metadata; scope is narrow and covered by new unit tests.
> 
> **Overview**
> Catalog initialization now resolves timezone through a shared **`catalogTimeZone`** helper instead of reading only the **`timezone`** property. When **`timezone`** is unset, **`option.use_time_zone`** is used as a fallback (still stripped from **`NodeSpec`** client options). An explicit **`timezone`** value continues to win over the ClickHouse client option.
> 
> The same logic is applied across Spark **3.3**, **3.4**, **3.5**, and **4.0**, with unit tests covering fallback, precedence, and that **`use_time_zone`** is not passed through to the client option map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967416d7605f3e8dad1ccac1db56af6a1d04e6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->