### PR TITLE
ci: run cloud metrics against Spark 4.0 only

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -48,16 +48,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spark: [ '3.3', '3.4', '3.5', '4.0' ]
-        scala: [ '2.12', '2.13' ]
-        java: [ 8, 17 ]
-        exclude:
-          # Spark 4.0 only supports Scala 2.13
-          - spark: '4.0'
-            scala: '2.12'
-          # Spark 4.0 requires Java 17+
-          - spark: '4.0'
-            java: 8
+        # Cloud metrics run against Spark 4.0 only (Scala 2.13 + Java 17).
+        spark: [ '4.0' ]
+        scala: [ '2.13' ]
+        java: [ 17 ]
     env:
       CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
       CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}


### PR DESCRIPTION
Drop Spark 3.3/3.4/3.5, Scala 2.12, and Java 8 from the ClickHouse Cloud test matrix. Cloud metrics now run a single combination: Spark 4.0 / Scala 2.13 / Java 17.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that reduces CI coverage breadth without touching application or connector runtime code.
> 
> **Overview**
> Narrows the **ClickHouse Cloud** workflow matrix so `cloudTest` runs on a single toolchain instead of the previous multi-version grid.
> 
> The job matrix is reduced from Spark **3.3–4.0**, Scala **2.12/2.13**, and Java **8/17** (with excludes for Spark 4.0) to **Spark 4.0**, **Scala 2.13**, and **Java 17** only, with an inline comment documenting that cloud metrics target Spark 4.0. Trigger rules, secrets, Gradle invocation, and artifact naming are unchanged aside from fewer matrix legs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb77e134bb08340e0a67a12b8097d02f21c07113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->