### PR TITLE
ci: nightly dispatcher for the clickbench-load-test benchmark

### DIFF
--- a/.github/workflows/clickbench-nightly-dispatch.yml
+++ b/.github/workflows/clickbench-nightly-dispatch.yml
@@ -1,0 +1,44 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Nightly dispatcher for the ClickBench load-test benchmark.
+#
+# GitHub only evaluates `schedule` triggers on the default branch, and the
+# benchmark workflow deliberately lives on the long-running
+# `clickbench-load-test` branch (its CI OIDC role trust is pinned to that
+# ref). This shim is the only benchmark piece that needs to live on the
+# default branch: it fires a workflow_dispatch at the branch workflow every
+# night and does nothing else. Delete it if/when the benchmark workflow
+# merges to the default branch and can carry its own schedule.
+
+name: "ClickBench nightly dispatch"
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 02:00 UTC nightly
+  workflow_dispatch: {}    # manual test of the dispatcher itself
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch clickbench-load-test on its branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run clickbench-load-test.yml \
+            --repo "${{ github.repository }}" \
+            --ref clickbench-load-test


### PR DESCRIPTION
Adds a ~20-line scheduler shim to the default branch that fires a `workflow_dispatch` at the ClickBench benchmark workflow on the `clickbench-load-test` branch every night at 02:00 UTC.

**Why a shim:** GitHub evaluates `schedule` triggers only on the default branch. The benchmark workflow deliberately lives on the long-running `clickbench-load-test` branch (#551) — its CI OIDC role trust is pinned to that ref — so it cannot schedule itself until it merges. This dispatcher is the minimal default-branch footprint that gives the benchmark a nightly cadence in the meantime.

- Uses the repo `GITHUB_TOKEN` with `actions: write` (workflow_dispatch events created by `GITHUB_TOKEN` do trigger workflow runs — the recursive-run exclusion does not apply to `workflow_dispatch`).
- The benchmark's own `concurrency` group already prevents overlapping runs.
- A manual `workflow_dispatch` trigger is included to test the dispatcher itself.
- Delete this file when the benchmark workflow merges to the default branch and can carry its own cron.

Verified today: a manual dispatch of the branch workflow ran the full HEAD-vs-pinned pair green in ~40 min (run 30750266654).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9sRCYEDZw1XMdGhpvJ9uE